### PR TITLE
Fixes #30:  Escapes all special characters to their HTML entities.

### DIFF
--- a/app/models/scheduled_message.rb
+++ b/app/models/scheduled_message.rb
@@ -3,15 +3,17 @@ class ScheduledMessage < ActiveRecord::Base
   validates :days_after_start, presence: true
   validates :title, presence: true
 
-  before_save :escape_special_characters
+  before_save :escape_specific_characters
 
   def body
-    self[:body].html_safe
+    self[:body].html_safe if self[:body]
   end
 
   protected
 
-  def escape_special_characters
-    self.body = ERB::Util::html_escape(self[:body])
+  def escape_specific_characters
+    self.body = self[:body].gsub('&', '&amp;')
+    self.body = self[:body].gsub('<', '&lt;')
+    self.body = self[:body].gsub('>', '&gt;')
   end
 end

--- a/app/models/scheduled_message.rb
+++ b/app/models/scheduled_message.rb
@@ -2,18 +2,4 @@ class ScheduledMessage < ActiveRecord::Base
   validates :body, presence: true
   validates :days_after_start, presence: true
   validates :title, presence: true
-
-  before_save :escape_specific_characters
-
-  def body
-    self[:body].html_safe if self[:body]
-  end
-
-  protected
-
-  def escape_specific_characters
-    self.body = self[:body].gsub('&', '&amp;')
-    self.body = self[:body].gsub('<', '&lt;')
-    self.body = self[:body].gsub('>', '&gt;')
-  end
 end

--- a/app/models/scheduled_message.rb
+++ b/app/models/scheduled_message.rb
@@ -2,4 +2,16 @@ class ScheduledMessage < ActiveRecord::Base
   validates :body, presence: true
   validates :days_after_start, presence: true
   validates :title, presence: true
+
+  before_save :escape_special_characters
+
+  def body
+    self[:body].html_safe
+  end
+
+  protected
+
+  def escape_special_characters
+    self.body = ERB::Util::html_escape(self[:body])
+  end
 end

--- a/app/services/message_formatter.rb
+++ b/app/services/message_formatter.rb
@@ -4,7 +4,7 @@ class MessageFormatter
   end
 
   def escape_slack_characters
-    escaped_body = message_body
+    escaped_body = message.body
     escaped_body = escaped_body.gsub('&', '&amp;')
     escaped_body = escaped_body.gsub('<', '&lt;')
     escaped_body = escaped_body.gsub('>', '&gt;')
@@ -14,8 +14,4 @@ class MessageFormatter
   private
 
   attr_reader :message
-
-  def message_body
-    message.body || ""
-  end
 end

--- a/app/services/message_formatter.rb
+++ b/app/services/message_formatter.rb
@@ -1,0 +1,21 @@
+class MessageFormatter
+  def initialize(message)
+    @message = message
+  end
+
+  def escape_slack_characters
+    escaped_body = message_body
+    escaped_body = escaped_body.gsub('&', '&amp;')
+    escaped_body = escaped_body.gsub('<', '&lt;')
+    escaped_body = escaped_body.gsub('>', '&gt;')
+    escaped_body
+  end
+
+  private
+
+  attr_reader :message
+
+  def message_body
+    message.body || ""
+  end
+end

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -62,7 +62,7 @@ class MessageSender
       scheduled_message: options[:scheduled_message],
       sent_on: Date.current,
       error_message: error_message(options[:error]),
-      message_body: options[:scheduled_message].body
+      message_body: MessageFormatter.new(options[:scheduled_message]).escape_slack_characters
     )
   end
 

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -62,7 +62,7 @@ class MessageSender
       scheduled_message: options[:scheduled_message],
       sent_on: Date.current,
       error_message: error_message(options[:error]),
-      message_body: options[:scheduled_message].body,
+      message_body: options[:scheduled_message].body
     )
   end
 

--- a/spec/services/message_formatter_spec.rb
+++ b/spec/services/message_formatter_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe MessageFormatter do
+  describe "#escape_slack_characters" do
+    it "escapes specific characters (&, <, and >) as defined by the Slack Message API" do
+      scheduled_message = create(
+        :scheduled_message,
+        body: "This is a \"message\" with &, <, and > characters that should be escaped and some 'others' that _should_ *not* be!"
+      )
+      formatted_message_body = MessageFormatter.new(scheduled_message).escape_slack_characters
+
+      expect(formatted_message_body).to eq(
+          "This is a \"message\" with &amp;, &lt;, and &gt; characters that should be escaped and some 'others' that _should_ *not* be!",
+      )
+    end
+  end
+end


### PR DESCRIPTION
This will escape all special characters to their corresponding HTML entities, but it will also display the messages normally when viewing/editing them.

My Rails-fu is not as great as my Django-fu, so if there is a better way of accomplishing this please let me know!