### PR TITLE
Issue #33:  Slack Username Validation

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -48,6 +48,6 @@ class EmployeesController < ApplicationController
   end
 
   def unknown_employee(slack_username)
-    !EmployeeFinder.new.employee_exists?(slack_username)
+    !EmployeeFinder.new(slack_username).existing_employee?
   end
 end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -6,13 +6,10 @@ class EmployeesController < ApplicationController
   def create
     @employee = Employee.new(employee_params)
 
-    unless EmployeeFinder.new.employee_exists?(@employee.slack_username)
-      flash.now[:error] = "\"#{@employee.slack_username}\" is not a valid employee (that username was not found)."
+    if unknown_employee(@employee.slack_username)
+      flash.now[:error] = "There is not a slack user with the username \"#{@employee.slack_username}\" in your organization."
       render action: :new
-      return
-    end
-
-    if @employee.save
+    elsif @employee.save
       flash[:notice] = "Thanks for adding #{@employee.slack_username}"
       redirect_to root_path
     else
@@ -32,13 +29,10 @@ class EmployeesController < ApplicationController
   def update
     @employee = Employee.find(params[:id])
 
-    unless EmployeeFinder.new.employee_exists?(@employee.slack_username)
-      flash.now[:error] = "\"#{@employee.slack_username}\" is not a valid employee (that username was not found)."
+    if unknown_employee(params[:employee][:slack_username])
+      flash.now[:error] = "There is not a slack user with the username \"#{params[:employee][:slack_username]}\" in your organization."
       render action: :edit
-      return
-    end
-
-    if @employee.update(employee_params)
+    elsif @employee.update(employee_params)
       flash[:notice] = "Employee updated successfully"
       redirect_to employees_path
     else
@@ -51,5 +45,9 @@ class EmployeesController < ApplicationController
 
   def employee_params
     params.require(:employee).permit(:slack_username, :started_on)
+  end
+
+  def unknown_employee(slack_username)
+    !EmployeeFinder.new.employee_exists?(slack_username)
   end
 end

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -6,6 +6,12 @@ class EmployeesController < ApplicationController
   def create
     @employee = Employee.new(employee_params)
 
+    unless EmployeeFinder.new.employee_exists?(@employee.slack_username)
+      flash.now[:error] = "\"#{@employee.slack_username}\" is not a valid employee (that username was not found)."
+      render action: :new
+      return
+    end
+
     if @employee.save
       flash[:notice] = "Thanks for adding #{@employee.slack_username}"
       redirect_to root_path
@@ -25,6 +31,12 @@ class EmployeesController < ApplicationController
 
   def update
     @employee = Employee.find(params[:id])
+
+    unless EmployeeFinder.new.employee_exists?(@employee.slack_username)
+      flash.now[:error] = "\"#{@employee.slack_username}\" is not a valid employee (that username was not found)."
+      render action: :edit
+      return
+    end
 
     if @employee.update(employee_params)
       flash[:notice] = "Employee updated successfully"

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,4 +1,13 @@
 class Employee < ActiveRecord::Base
-  validates :slack_username, presence: true, uniqueness: true, format: { with: /\A[a-z_0-9.]+\z/ }
+  validates :slack_username, presence: true, uniqueness: true, format: { with: /\A[a-z_0-9.]+\z/, message: "Slack usernames can only contain lowercase letters, numbers, underscores, and periods." }
   validates :started_on, presence: true
+
+  validate :slack_user_exists
+
+  def slack_user_exists
+    errors.add(
+      :slack_username,
+      "\"#{self[:slack_username]}\" is not a valid employee (that username was not found)."
+    ) unless EmployeeFinder.new.employee_exists?(self[:slack_username])
+  end
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,4 +1,4 @@
 class Employee < ActiveRecord::Base
-  validates :slack_username, presence: true, uniqueness: true
+  validates :slack_username, presence: true, uniqueness: true, format: { with: /\A[a-z_0-9.]+\z/ }
   validates :started_on, presence: true
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,13 +1,4 @@
 class Employee < ActiveRecord::Base
   validates :slack_username, presence: true, uniqueness: true, format: { with: /\A[a-z_0-9.]+\z/, message: "Slack usernames can only contain lowercase letters, numbers, underscores, and periods." }
   validates :started_on, presence: true
-
-  validate :slack_user_exists
-
-  def slack_user_exists
-    errors.add(
-      :slack_username,
-      "\"#{self[:slack_username]}\" is not a valid employee (that username was not found)."
-    ) unless EmployeeFinder.new.employee_exists?(self[:slack_username])
-  end
 end

--- a/app/services/employee_finder.rb
+++ b/app/services/employee_finder.rb
@@ -1,12 +1,13 @@
 require "slack-ruby-client"
 
 class EmployeeFinder
-  def initialize
+  def initialize(slack_username)
+    @slack_username = slack_username
     configure_slack
   end
 
-  def employee_exists?(slack_username)
-    SlackUserFinder.new(slack_username, client).user_exists?
+  def existing_employee?
+    SlackUserFinder.new(@slack_username, client).existing_user?
   end
 
   private

--- a/app/services/employee_finder.rb
+++ b/app/services/employee_finder.rb
@@ -1,0 +1,23 @@
+require "slack-ruby-client"
+
+class EmployeeFinder
+  def initialize
+    configure_slack
+  end
+
+  def employee_exists?(slack_username)
+    SlackUserFinder.new(slack_username, client).user_exists?
+  end
+
+  private
+
+  def configure_slack
+    Slack.configure do |config|
+      config.token = ENV['SLACK_API_TOKEN']
+    end
+  end
+
+  def client
+    @client ||= Slack::Web::Client.new
+  end
+end

--- a/app/services/slack_api_wrapper.rb
+++ b/app/services/slack_api_wrapper.rb
@@ -1,0 +1,20 @@
+class SlackApiWrapper
+  def initialize(slack_username, client)
+    @slack_username = slack_username
+    @client = client
+  end
+
+  private
+
+  attr_accessor :client, :slack_username
+
+  def slack_user
+    @slack_user ||= all_slack_users.find do |user_data|
+      user_data["name"] == slack_username
+    end
+  end
+
+  def all_slack_users
+    client.users_list["members"]
+  end
+end

--- a/app/services/slack_channel_id_finder.rb
+++ b/app/services/slack_channel_id_finder.rb
@@ -1,28 +1,9 @@
-class SlackChannelIdFinder
-  def initialize(slack_username, client)
-    @slack_username = slack_username
-    @client = client
-  end
-
+class SlackChannelIdFinder < SlackApiWrapper
   def run
     if slack_user
       slack_user_id = slack_user["id"]
       chat = client.im_open(user: slack_user_id)
       chat["channel"]["id"]
     end
-  end
-
-  private
-
-  attr_accessor :client, :slack_username
-
-  def slack_user
-    @slack_user ||= all_slack_users.find do |user_data|
-      user_data["name"] == slack_username
-    end
-  end
-
-  def all_slack_users
-    client.users_list["members"]
   end
 end

--- a/app/services/slack_user_finder.rb
+++ b/app/services/slack_user_finder.rb
@@ -1,0 +1,5 @@
+class SlackUserFinder < SlackApiWrapper
+  def user_exists?
+    !slack_user.nil?
+  end
+end

--- a/app/services/slack_user_finder.rb
+++ b/app/services/slack_user_finder.rb
@@ -1,5 +1,5 @@
 class SlackUserFinder < SlackApiWrapper
-  def user_exists?
+  def existing_user?
     !slack_user.nil?
   end
 end

--- a/spec/features/create_employees_spec.rb
+++ b/spec/features/create_employees_spec.rb
@@ -5,7 +5,7 @@ feature "Create employees" do
     login_with_oauth
     visit root_path
 
-    username = "test_slack_username_3000"
+    username = "testusername2"
     fill_in "Slack username", with: username
     select "2015", from: "employee_started_on_1i"
     select "June", from: "employee_started_on_2i"

--- a/spec/features/create_employees_spec.rb
+++ b/spec/features/create_employees_spec.rb
@@ -14,4 +14,18 @@ feature "Create employees" do
 
     expect(page).to have_content("Thanks for adding #{username}")
   end
+
+  scenario "unsuccessfully with invalid username" do
+    login_with_oauth
+    visit root_path
+
+    username = "fakeusername2"
+    fill_in "Slack username", with: username
+    select "2015", from: "employee_started_on_1i"
+    select "June", from: "employee_started_on_2i"
+    select "1", from: "employee_started_on_3i"
+    click_on "Create Employee"
+
+    expect(page).to have_content("There is not a slack user with the username \"#{username}\" in your organization.")
+  end
 end

--- a/spec/features/edit_employees_spec.rb
+++ b/spec/features/edit_employees_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 feature "Edit employees" do
   scenario "from list of employees" do
-    old_slack_username = "old_name_333"
-    new_slack_username = "new_name_555"
+    old_slack_username = "testusername"
+    new_slack_username = "testusername3"
     create(:employee, slack_username: old_slack_username)
 
     login_with_oauth

--- a/spec/features/edit_employees_spec.rb
+++ b/spec/features/edit_employees_spec.rb
@@ -15,4 +15,18 @@ feature "Edit employees" do
     expect(page).to have_content "Employee updated successfully"
     expect(page).to have_content new_slack_username
   end
+
+  scenario "unsuccessfully due to an invalid username" do
+    old_slack_username = "testusername"
+    new_slack_username = "fakeusername3"
+    create(:employee, slack_username: old_slack_username)
+
+    login_with_oauth
+    visit employees_path
+    click_on "Edit"
+    fill_in "Slack username", with: new_slack_username
+    click_on "Update Employee"
+
+    expect(page).to have_content("There is not a slack user with the username \"#{new_slack_username}\" in your organization.")
+  end
 end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -5,9 +5,6 @@ describe Employee do
      subject { create(:employee) }
      it { should validate_presence_of(:slack_username) }
      it { should validate_uniqueness_of(:slack_username) }
-     # These fail - why?
-     #it { should allow_values("test_user_1", "testuser2", "test.user.3").for(:slack_username) }
-     #it { should_not allow_values("TEST USER 1", "test_user_2?", "test'user'3").for(:slack_username) }
      it { should allow_value("test_user_1").for(:slack_username) }
      it { should_not allow_value("TEST USER 1").for(:slack_username) }
      it { should validate_presence_of(:started_on) }

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -5,6 +5,11 @@ describe Employee do
      subject { create(:employee) }
      it { should validate_presence_of(:slack_username) }
      it { should validate_uniqueness_of(:slack_username) }
+     # These fail - why?
+     #it { should allow_values("test_user_1", "testuser2", "test.user.3").for(:slack_username) }
+     #it { should_not allow_values("TEST USER 1", "test_user_2?", "test'user'3").for(:slack_username) }
+     it { should allow_value("test_user_1").for(:slack_username) }
+     it { should_not allow_value("TEST USER 1").for(:slack_username) }
      it { should validate_presence_of(:started_on) }
   end
 end

--- a/spec/services/employee_finder_spec.rb
+++ b/spec/services/employee_finder_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe EmployeeFinder do
   describe "#employee_exists?" do
-    it "returns true if an employee exists in Slack" do
+    it "returns true if an employee exists in the Slack organization associated with the auth token" do
       employee = create(:employee)
       client_double = Slack::Web::Client.new
       existing_user_double = double(existing_user?: true)
@@ -17,7 +17,7 @@ describe EmployeeFinder do
       expect(employee_finder).to be_existing_employee
     end
 
-    it "returns false if an employee does not exist in Slack" do
+    it "rreturns false if an employee does not exist in the Slack organization associated with the auth token" do
       employee = create(:employee)
       client_double = Slack::Web::Client.new
       existing_user_double = double(existing_user?: false)

--- a/spec/services/employee_finder_spec.rb
+++ b/spec/services/employee_finder_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe EmployeeFinder do
+  describe "#employee_exists?" do
+    it "returns true if an employee exists in Slack" do
+      employee = create(:employee)
+      client_double = Slack::Web::Client.new
+      slack_user_finder_double = double(users_exists?: true)
+
+      allow(Slack::Web::Client).to receive(:new).and_return(client_double)
+      allow(SlackUserFinder).
+        to receive(:new).with(employee.slack_username, client_double).
+        and_return(slack_user_finder_double)
+
+      employee_exists = EmployeeFinder.new.employee_exists?(employee.slack_username)
+
+      expect(employee_exists).to be true
+    end
+
+    it "returns false if an employee does not exist in Slack" do
+      employee = create(:employee)
+      client_double = Slack::Web::Client.new
+      slack_user_finder_double = double(users_exists?: false)
+
+      allow(Slack::Web::Client).to receive(:new).and_return(client_double)
+      allow(SlackUserFinder).
+        to receive(:new).with(employee.slack_username, client_double).
+        and_return(slack_user_finder_double)
+
+      employee_exists = EmployeeFinder.new.employee_exists?(employee.slack_username)
+
+      expect(employee_exists).to be false
+    end
+  end
+end

--- a/spec/services/employee_finder_spec.rb
+++ b/spec/services/employee_finder_spec.rb
@@ -5,12 +5,12 @@ describe EmployeeFinder do
     it "returns true if an employee exists in Slack" do
       employee = create(:employee)
       client_double = Slack::Web::Client.new
-      slack_user_finder_double = double(users_exists?: true)
+      user_exists_double = double(user_exists?: true)
 
       allow(Slack::Web::Client).to receive(:new).and_return(client_double)
       allow(SlackUserFinder).
         to receive(:new).with(employee.slack_username, client_double).
-        and_return(slack_user_finder_double)
+        and_return(user_exists_double)
 
       employee_exists = EmployeeFinder.new.employee_exists?(employee.slack_username)
 
@@ -20,12 +20,12 @@ describe EmployeeFinder do
     it "returns false if an employee does not exist in Slack" do
       employee = create(:employee)
       client_double = Slack::Web::Client.new
-      slack_user_finder_double = double(users_exists?: false)
+      user_exists_double = double(user_exists?: false)
 
       allow(Slack::Web::Client).to receive(:new).and_return(client_double)
       allow(SlackUserFinder).
         to receive(:new).with(employee.slack_username, client_double).
-        and_return(slack_user_finder_double)
+        and_return(user_exists_double)
 
       employee_exists = EmployeeFinder.new.employee_exists?(employee.slack_username)
 

--- a/spec/services/employee_finder_spec.rb
+++ b/spec/services/employee_finder_spec.rb
@@ -5,31 +5,31 @@ describe EmployeeFinder do
     it "returns true if an employee exists in Slack" do
       employee = create(:employee)
       client_double = Slack::Web::Client.new
-      user_exists_double = double(user_exists?: true)
+      existing_user_double = double(existing_user?: true)
 
       allow(Slack::Web::Client).to receive(:new).and_return(client_double)
       allow(SlackUserFinder).
         to receive(:new).with(employee.slack_username, client_double).
-        and_return(user_exists_double)
+        and_return(existing_user_double)
 
-      employee_exists = EmployeeFinder.new.employee_exists?(employee.slack_username)
+      employee_finder = EmployeeFinder.new(employee.slack_username)
 
-      expect(employee_exists).to be true
+      expect(employee_finder).to be_existing_employee
     end
 
     it "returns false if an employee does not exist in Slack" do
       employee = create(:employee)
       client_double = Slack::Web::Client.new
-      user_exists_double = double(user_exists?: false)
+      existing_user_double = double(existing_user?: false)
 
       allow(Slack::Web::Client).to receive(:new).and_return(client_double)
       allow(SlackUserFinder).
         to receive(:new).with(employee.slack_username, client_double).
-        and_return(user_exists_double)
+        and_return(existing_user_double)
 
-      employee_exists = EmployeeFinder.new.employee_exists?(employee.slack_username)
+      employee_finder = EmployeeFinder.new(employee.slack_username)
 
-      expect(employee_exists).to be false
+      expect(employee_finder).not_to be_existing_employee
     end
   end
 end

--- a/spec/services/slack_user_finder_spec.rb
+++ b/spec/services/slack_user_finder_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe SlackUserFinder do
-  describe "#user_exists?" do
+  describe "#existing_user?" do
     it "returns true if a user is found" do
       slack_username_from_fixture = "testusername"
 
@@ -10,7 +10,7 @@ describe SlackUserFinder do
         Slack::Web::Client.new
       )
 
-      expect(user).to be_user_exists
+      expect(user).to be_existing_user
     end
 
     it "returns false if a user was not found" do
@@ -21,7 +21,7 @@ describe SlackUserFinder do
         Slack::Web::Client.new
       )
 
-      expect(user).not_to be_user_exists
+      expect(user).not_to be_existing_user
     end
   end
 end

--- a/spec/services/slack_user_finder_spec.rb
+++ b/spec/services/slack_user_finder_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe SlackUserFinder do
+  describe "#user_exists?" do
+    it "returns true if a user is found" do
+      slack_username_from_fixture = "testusername"
+
+      user_exists = SlackUserFinder.new(
+        slack_username_from_fixture,
+        Slack::Web::Client.new
+      ).user_exists?
+
+      expect(user_exists).to be true
+    end
+
+    it "returns false if a user was not found" do
+      fake_slack_user_name = "testusernamethatdoesnotexist"
+
+      user_exists = SlackUserFinder.new(
+        fake_slack_user_name,
+        Slack::Web::Client.new
+      ).user_exists?
+
+      expect(user_exists).to be false
+    end
+  end
+end

--- a/spec/services/slack_user_finder_spec.rb
+++ b/spec/services/slack_user_finder_spec.rb
@@ -5,23 +5,23 @@ describe SlackUserFinder do
     it "returns true if a user is found" do
       slack_username_from_fixture = "testusername"
 
-      user_exists = SlackUserFinder.new(
+      user = SlackUserFinder.new(
         slack_username_from_fixture,
         Slack::Web::Client.new
-      ).user_exists?
+      )
 
-      expect(user_exists).to be true
+      expect(user).to be_user_exists
     end
 
     it "returns false if a user was not found" do
       fake_slack_user_name = "testusernamethatdoesnotexist"
 
-      user_exists = SlackUserFinder.new(
+      user = SlackUserFinder.new(
         fake_slack_user_name,
         Slack::Web::Client.new
-      ).user_exists?
+      )
 
-      expect(user_exists).to be false
+      expect(user).not_to be_user_exists
     end
   end
 end

--- a/spec/support/fixtures/users_list.json
+++ b/spec/support/fixtures/users_list.json
@@ -16,6 +16,38 @@
         "is_owner": true,
         "has_2fa": false,
         "has_files": true
+      },
+      {
+        "id": "456DEF_ID",
+        "name": "testusername2",
+        "deleted": false,
+        "color": "9f69e7",
+        "profile": {
+          "first_name": "Joe",
+          "last_name": "Smith",
+          "real_name": "Joe Smith",
+          "email": "joe@slack.com"
+        },
+        "is_admin": true,
+        "is_owner": true,
+        "has_2fa": false,
+        "has_files": true
+      },
+      {
+        "id": "789GHI_ID",
+        "name": "testusername3",
+        "deleted": false,
+        "color": "9f69e7",
+        "profile": {
+          "first_name": "Jane",
+          "last_name": "Smith",
+          "real_name": "Jane Smith",
+          "email": "jane@slack.com"
+        },
+        "is_admin": true,
+        "is_owner": true,
+        "has_2fa": false,
+        "has_files": true
       }
     ]
 }


### PR DESCRIPTION
This is the initial changeset with full support and passing tests for the Slack username validation.  There is still one outstanding thing to investigate further with the employee model validation tests as the "allow_values" shoulda matcher method seems to be failing.  I want to look into that a bit further to see if it's something that needs to be reported to the shoulda matchers (and gather full details if so), but otherwise this is ready for review and discussion!  Thank you @jessieay for your help with this and coming up with a cleaner approach, especially with the tests!