### PR TITLE
Connects #28:  Initial support for tags on scheduled messages.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby "2.2.3"
 
+gem "acts-as-taggable-on"
 gem "clockwork"
 gem "daemons" # for delayed_job
 gem "delayed_job_active_record"
@@ -40,4 +41,4 @@ end
 group :staging, :production do
   gem "rack-timeout"
   gem "rails_12factor"
-end 
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (3.5.0)
+      activerecord (>= 3.2, < 5)
     addressable (2.3.8)
     arel (6.0.3)
     awesome_print (1.6.1)
@@ -252,6 +254,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on
   awesome_print
   bundler-audit
   byebug

--- a/app/controllers/scheduled_messages_controller.rb
+++ b/app/controllers/scheduled_messages_controller.rb
@@ -38,6 +38,6 @@ class ScheduledMessagesController < ApplicationController
   private
 
   def scheduled_message_params
-    params.require(:scheduled_message).permit(:body, :days_after_start, :title, :tag_list)
+    params.require(:scheduled_message).permit(:body, :days_after_start, :tag_list, :title)
   end
 end

--- a/app/controllers/scheduled_messages_controller.rb
+++ b/app/controllers/scheduled_messages_controller.rb
@@ -38,6 +38,6 @@ class ScheduledMessagesController < ApplicationController
   private
 
   def scheduled_message_params
-    params.require(:scheduled_message).permit(:body, :days_after_start, :title)
+    params.require(:scheduled_message).permit(:body, :days_after_start, :title, :tag_list)
   end
 end

--- a/app/models/scheduled_message.rb
+++ b/app/models/scheduled_message.rb
@@ -1,6 +1,7 @@
 class ScheduledMessage < ActiveRecord::Base
   validates :body, presence: true
   validates :days_after_start, presence: true
+  validates :tag_list, presence: true
   validates :title, presence: true
 
   acts_as_taggable

--- a/app/models/scheduled_message.rb
+++ b/app/models/scheduled_message.rb
@@ -2,4 +2,6 @@ class ScheduledMessage < ActiveRecord::Base
   validates :body, presence: true
   validates :days_after_start, presence: true
   validates :title, presence: true
+
+  acts_as_taggable
 end

--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -1,8 +1,8 @@
 <%= simple_form_for @scheduled_message do |form| %>
   <%= form.input :title,
-    hint: "This is for identifying purposes only, the employee will not see the message title" %>
+    hint: "This is for identifying purposes only, the employee will not see the message title." %>
   <%= form.input :body, label: "Message body" %>
   <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
-  <%= form.input :tag_list, label: "Tags (separated by commas)" %>
+  <%= form.input :tag_list, label: "Tags", hint: "Separate tags with spaces to enter multiple tags at once." %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -3,6 +3,6 @@
     hint: "This is for identifying purposes only, the employee will not see the message title." %>
   <%= form.input :body, label: "Message body" %>
   <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
-  <%= form.input :tag_list, label: "Tags", hint: "Separate tags with spaces to enter multiple tags at once." %>
+  <%= form.input :tag_list, label: "Tags", hint: "Separate tags with commas to enter multiple tags at once." %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -3,6 +3,6 @@
     hint: "This is for identifying purposes only, the employee will not see the message title" %>
   <%= form.input :body, label: "Message body" %>
   <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
-  <%= form.input :tag_list, label: "Tags (seperated by commas)" %>
+  <%= form.input :tag_list, label: "Tags (separated by commas)" %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -3,5 +3,6 @@
     hint: "This is for identifying purposes only, the employee will not see the message title" %>
   <%= form.input :body, label: "Message body" %>
   <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
+  <%= form.input :tag_list, label: "Tags (seperated by commas)" %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/scheduled_messages/index.html.erb
+++ b/app/views/scheduled_messages/index.html.erb
@@ -3,6 +3,7 @@
     <th>Send day (after employee start)</th>
     <th>Title</th>
     <th>Body</th>
+    <th>Tags</th>
     <th></th>
     <th></th>
   </tr>
@@ -12,6 +13,7 @@
       <td><%= message.days_after_start %></td>
       <td><%= message.title %></td>
       <td><%= message.body %></td>
+      <td><%= message.tag_list.join(", ") %></td>
       <td><%= link_to "Edit", edit_scheduled_message_path(message) %></td>
       <td><%= link_to "Test", new_scheduled_message_test_message_path(message) %></td>
     </tr>

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,0 +1,1 @@
+ActsAsTaggableOn.delimiter = " "

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,1 +1,0 @@
-ActsAsTaggableOn.delimiter = " "

--- a/db/migrate/20151006161910_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20151006161910_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,31 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20151006161911_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20151006161911_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20151006161912_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20151006161912_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20151006161913_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20151006161913_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20151006161914_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20151006161914_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150923224817) do
+ActiveRecord::Schema.define(version: 20151006161914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,5 +58,25 @@ ActiveRecord::Schema.define(version: 20150923224817) do
   end
 
   add_index "sent_scheduled_messages", ["employee_id", "scheduled_message_id"], name: "by_employee_scheduled_message", unique: true, using: :btree
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id"
+    t.integer  "taggable_id"
+    t.string   "taggable_type"
+    t.integer  "tagger_id"
+    t.string   "tagger_type"
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+  end
+
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+
+  create_table "tags", force: :cascade do |t|
+    t.string  "name"
+    t.integer "taggings_count", default: 0
+  end
+
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,6 +17,6 @@ FactoryGirl.define do
     title "Onboarding message 1"
     body "This is an awesome message!"
     days_after_start 3
-    tag_list "test_tag test_tag_two"
+    tag_list "test_tag, test_tag_two"
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,5 +17,6 @@ FactoryGirl.define do
     title "Onboarding message 1"
     body "This is an awesome message!"
     days_after_start 3
+    tag_list "test_tag test_tag_two"
   end
 end

--- a/spec/features/create_scheduled_message_spec.rb
+++ b/spec/features/create_scheduled_message_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Create scheduled message" do
-  scenario "successfully without tags" do
+  scenario "successfully" do
     login_with_oauth
     visit root_path
     click_on "Create scheduled message"
@@ -9,22 +9,22 @@ feature "Create scheduled message" do
     fill_in "Title", with: "Message title"
     fill_in "Message body", with: "Message body"
     fill_in "Days after employee starts to send message", with: 1
+    fill_in "Tags", with: "tag_one tag_two tag_three"
     click_on "Create Scheduled message"
 
     expect(page).to have_content("Scheduled message created successfully")
   end
 
-  scenario "successfully with tags" do
+  scenario "unsuccessfully due to missing required fields" do
     login_with_oauth
     visit root_path
     click_on "Create scheduled message"
 
     fill_in "Title", with: "Message title"
-    fill_in "Message body", with: "Message body"
     fill_in "Days after employee starts to send message", with: 1
-    fill_in "Tags (separated by commas)", with: "tag_one tag_two tag_three"
     click_on "Create Scheduled message"
 
-    expect(page).to have_content("Scheduled message created successfully")
+    expect(page).to have_content("Could not create scheduled message")
+    expect(page).to have_content("can't be blank")
   end
 end

--- a/spec/features/create_scheduled_message_spec.rb
+++ b/spec/features/create_scheduled_message_spec.rb
@@ -9,7 +9,7 @@ feature "Create scheduled message" do
     fill_in "Title", with: "Message title"
     fill_in "Message body", with: "Message body"
     fill_in "Days after employee starts to send message", with: 1
-    fill_in "Tags", with: "tag_one tag_two tag_three"
+    fill_in "Tags", with: "tag_one, tag_two, tag_three"
     click_on "Create Scheduled message"
 
     expect(page).to have_content("Scheduled message created successfully")

--- a/spec/features/create_scheduled_message_spec.rb
+++ b/spec/features/create_scheduled_message_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Create scheduled message" do
-  scenario "successfully" do
+  scenario "successfully without tags" do
     login_with_oauth
     visit root_path
     click_on "Create scheduled message"
@@ -9,6 +9,20 @@ feature "Create scheduled message" do
     fill_in "Title", with: "Message title"
     fill_in "Message body", with: "Message body"
     fill_in "Days after employee starts to send message", with: 1
+    click_on "Create Scheduled message"
+
+    expect(page).to have_content("Scheduled message created successfully")
+  end
+
+  scenario "successfully with tags" do
+    login_with_oauth
+    visit root_path
+    click_on "Create scheduled message"
+
+    fill_in "Title", with: "Message title"
+    fill_in "Message body", with: "Message body"
+    fill_in "Days after employee starts to send message", with: 1
+    fill_in "Tags (seperated by commas)", with: "tag_one tag_two tag_three"
     click_on "Create Scheduled message"
 
     expect(page).to have_content("Scheduled message created successfully")

--- a/spec/features/create_scheduled_message_spec.rb
+++ b/spec/features/create_scheduled_message_spec.rb
@@ -22,7 +22,7 @@ feature "Create scheduled message" do
     fill_in "Title", with: "Message title"
     fill_in "Message body", with: "Message body"
     fill_in "Days after employee starts to send message", with: 1
-    fill_in "Tags (seperated by commas)", with: "tag_one tag_two tag_three"
+    fill_in "Tags (separated by commas)", with: "tag_one tag_two tag_three"
     click_on "Create Scheduled message"
 
     expect(page).to have_content("Scheduled message created successfully")

--- a/spec/features/edit_scheduled_messages_spec.rb
+++ b/spec/features/edit_scheduled_messages_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 feature "Edit scheduled messages" do
-  scenario "from list of scheduled messages" do
+  scenario "from list of scheduled messages without tags" do
     old_title = "Old title"
     new_title = "New title"
     create(:scheduled_message, title: old_title)
@@ -14,5 +14,25 @@ feature "Edit scheduled messages" do
 
     expect(page).to have_content "Scheduled message updated successfully"
     expect(page).to have_content new_title
+  end
+
+  scenario "from list of scheduled messages with tags" do
+    old_title = "Old title"
+    new_title = "New title"
+    tags = "tag_one, tag_two, tag_three"
+    create(:scheduled_message, title: old_title)
+
+    login_with_oauth
+    visit scheduled_messages_path
+    click_on "Edit"
+    fill_in "Title", with: new_title
+    fill_in "Tags (seperated by commas)", with: tags
+    click_on "Update Scheduled message"
+
+    expect(page).to have_content "Scheduled message updated successfully"
+    expect(page).to have_content new_title
+    expect(page).to have_content "tag_one"
+    expect(page).to have_content "tag_two"
+    expect(page).to have_content "tag_three"
   end
 end

--- a/spec/features/edit_scheduled_messages_spec.rb
+++ b/spec/features/edit_scheduled_messages_spec.rb
@@ -26,7 +26,7 @@ feature "Edit scheduled messages" do
     visit scheduled_messages_path
     click_on "Edit"
     fill_in "Title", with: new_title
-    fill_in "Tags (seperated by commas)", with: tags
+    fill_in "Tags (separated by commas)", with: tags
     click_on "Update Scheduled message"
 
     expect(page).to have_content "Scheduled message updated successfully"

--- a/spec/features/edit_scheduled_messages_spec.rb
+++ b/spec/features/edit_scheduled_messages_spec.rb
@@ -1,32 +1,17 @@
 require "rails_helper"
 
 feature "Edit scheduled messages" do
-  scenario "from list of scheduled messages without tags" do
+  scenario "successfully" do
     old_title = "Old title"
     new_title = "New title"
+    tags = "tag_one tag_two tag_three"
     create(:scheduled_message, title: old_title)
 
     login_with_oauth
     visit scheduled_messages_path
     click_on "Edit"
     fill_in "Title", with: new_title
-    click_on "Update Scheduled message"
-
-    expect(page).to have_content "Scheduled message updated successfully"
-    expect(page).to have_content new_title
-  end
-
-  scenario "from list of scheduled messages with tags" do
-    old_title = "Old title"
-    new_title = "New title"
-    tags = "tag_one, tag_two, tag_three"
-    create(:scheduled_message, title: old_title)
-
-    login_with_oauth
-    visit scheduled_messages_path
-    click_on "Edit"
-    fill_in "Title", with: new_title
-    fill_in "Tags (separated by commas)", with: tags
+    fill_in "Tags", with: tags
     click_on "Update Scheduled message"
 
     expect(page).to have_content "Scheduled message updated successfully"
@@ -34,5 +19,22 @@ feature "Edit scheduled messages" do
     expect(page).to have_content "tag_one"
     expect(page).to have_content "tag_two"
     expect(page).to have_content "tag_three"
+  end
+
+  scenario "unsuccessfully due to missing required fields" do
+    old_title = "Old title"
+    new_title = "New title"
+    tags = ""
+    create(:scheduled_message, title: old_title)
+
+    login_with_oauth
+    visit scheduled_messages_path
+    click_on "Edit"
+    fill_in "Title", with: new_title
+    fill_in "Tags", with: tags
+    click_on "Update Scheduled message"
+
+    expect(page).to have_content "Could not update scheduled message"
+    expect(page).to have_content "can't be blank"
   end
 end

--- a/spec/features/edit_scheduled_messages_spec.rb
+++ b/spec/features/edit_scheduled_messages_spec.rb
@@ -4,7 +4,7 @@ feature "Edit scheduled messages" do
   scenario "successfully" do
     old_title = "Old title"
     new_title = "New title"
-    tags = "tag_one tag_two tag_three"
+    tags = "tag_one, tag_two, tag_three"
     create(:scheduled_message, title: old_title)
 
     login_with_oauth

--- a/spec/models/scheduled_message_spec.rb
+++ b/spec/models/scheduled_message_spec.rb
@@ -4,6 +4,7 @@ describe ScheduledMessage do
   describe "Validations" do
      it { should validate_presence_of(:body) }
      it { should validate_presence_of(:days_after_start) }
+     it { should validate_presence_of(:tag_list) }
      it { should validate_presence_of(:title) }
   end
 end


### PR DESCRIPTION
This changeset adds support for tags on scheduled messages via the acts_as_taggable_on gem.  New migrations are included and a couple of tests have been updated to account for the new functionality.