### PR TITLE
Slack Message Formatting

### DIFF
--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -1,7 +1,9 @@
 <%= simple_form_for @scheduled_message do |form| %>
   <%= form.input :title,
     hint: "This is for identifying purposes only, the employee will not see the message title." %>
-  <%= form.input :body, label: "Message body" %>
+  <%= form.input :body, label: "Message body", hint: "You can format your message via Slack's message formatting rules:" %>
+  <%= link_to "Slack Message Formatting Rules",
+    "https://slack.zendesk.com/hc/en-us/articles/202288908-Formatting-your-messages" %>
   <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
   <%= form.input :tag_list, label: "Tags", hint: "Separate tags with commas to enter multiple tags at once." %>
   <%= form.button :submit %>

--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -1,9 +1,9 @@
 <%= simple_form_for @scheduled_message do |form| %>
   <%= form.input :title,
-    hint: "This is for identifying purposes only, the employee will not see the message title." %>
-  <%= form.input :body, label: "Message body", hint: "You can format your message via Slack's message formatting rules:" %>
-  <%= link_to "Slack Message Formatting Rules",
-    "https://slack.zendesk.com/hc/en-us/articles/202288908-Formatting-your-messages" %>
+    hint: "This is for identifying purposes only, the employee will not see the message title" %>
+  <%= form.input :body, label: "Message body",
+    hint: "Don't forget, you can format your message using #{link_to "Slack's message formatting rules",
+    "https://slack.zendesk.com/hc/en-us/articles/202288908-Formatting-your-messages", target: "_blank"}.".html_safe %>
   <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
   <%= form.input :tag_list, label: "Tags", hint: "Separate tags with commas to enter multiple tags at once." %>
   <%= form.button :submit %>


### PR DESCRIPTION
Connects #59:  This small changeset simply adds a hint to the message input field with a link to the Slack documentation for the message formatting.