### PR TITLE
Connects #82:  Sets a new memory limit of 1GB for the Cloud Foundry deployments.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -6,12 +6,14 @@ command: script/start
 applications:
 - name: dolores-app
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+  memory: 1GB
   env:
     DEFAULT_URL_HOST: dolores-app.18f.gov
     DISABLE_SANDBOX_WARNING: true
     RESTRICT_ACCESS: true
 - name: dolores-staging
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
+  memory: 1GB
   env:
     DEFAULT_URL_HOST: dolores-staging.18f.gov
     DISABLE_SANDBOX_WARNING: true


### PR DESCRIPTION
This changeset adds the memory attribute to the manifest.yml file so that we set a higher limit for the app in Cloud Foundry.