### PR TITLE
Connects #76: Add support for time zones for employees and set times for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,25 @@ both 18F and the federal government.
 
 Please file an issue if you have any questions about Mrs. Landingham.
 
-## Usage Instructions
+### Usage Instructions
 
 **To add new users**
 
-Go https://dolores-app.18f.gov/
-Click https://dolores-app.18f.gov/employees/new
-Write their Slack username without the @ symbol
-Select the date that they started
-Click https://dolores-app.18f.gov/employees to make sure they’re on the list
+1. Go https://dolores-app.18f.gov/
+2. Click https://dolores-app.18f.gov/employees/new
+3. Write their Slack username without the @ symbol
+4. Select the date that they started
+5. Select the time zone that they reside in
+6. Click https://dolores-app.18f.gov/employees to make sure they’re on the list
 
 **To add new messages**
 
-Draft the message in this Google Doc
-Copy the message and paste it in the message body here: https://dolores-app.18f.gov/scheduled_messages/new
-Add a title to your message to be able to identify the message 
-Add the number of days after an employee starts. (Add 1 to the last message in this Google Doc)
-Add tags to be able to surface the message
+1. Draft the message in this Google Doc
+2. Copy the message and paste it in the message body here: https://dolores-app.18f.gov/scheduled_messages/new
+3. Add a title to your message to be able to identify the message 
+4. Add the number of days after an employee starts. (Add 1 to the last message in this Google Doc)
+5. Select a time that the message should be sent (the message will be sent at each employee's local time)
+6. Add tags to be able to surface the message
 
 
 ### Contributing

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,7 @@
   float: left;
   margin-right: 10px;
 }
+
+.date-time-select {
+    display: inline;
+}

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -1,6 +1,7 @@
 class EmployeesController < ApplicationController
   def new
     @employee = Employee.new
+    @employee.time_zone = "Eastern Time (US & Canada)"
   end
 
   def create
@@ -52,7 +53,7 @@ class EmployeesController < ApplicationController
   private
 
   def employee_params
-    params.require(:employee).permit(:slack_username, :started_on)
+    params.require(:employee).permit(:slack_username, :started_on, :time_zone)
   end
 
   def unknown_employee(slack_username)

--- a/app/controllers/scheduled_messages_controller.rb
+++ b/app/controllers/scheduled_messages_controller.rb
@@ -38,6 +38,6 @@ class ScheduledMessagesController < ApplicationController
   private
 
   def scheduled_message_params
-    params.require(:scheduled_message).permit(:body, :days_after_start, :tag_list, :title)
+    params.require(:scheduled_message).permit(:body, :days_after_start, :tag_list, :time_of_day, :title)
   end
 end

--- a/app/helpers/time_zone_display_helper.rb
+++ b/app/helpers/time_zone_display_helper.rb
@@ -1,0 +1,9 @@
+module TimeZoneDisplayHelper
+  def display_local_time_zone(sent_scheduled_message)
+    zone = ActiveSupport::TimeZone.new(sent_scheduled_message.employee.time_zone)
+    tz_offset = zone.now.strftime("%:z")
+    sent_local_time = sent_scheduled_message.sent_at.localtime(tz_offset)
+    sent_local_time_zone = sent_scheduled_message.sent_at.in_time_zone(sent_scheduled_message.employee.time_zone).zone
+    sent_local_time.strftime("%l:%M %p (#{sent_local_time_zone})").strip
+  end
+end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,4 +1,5 @@
 class Employee < ActiveRecord::Base
   validates :slack_username, presence: true, uniqueness: true, format: { with: /\A[a-z_0-9.]+\z/, message: "Slack usernames can only contain lowercase letters, numbers, underscores, and periods." }
   validates :started_on, presence: true
+  validates :time_zone, presence: true
 end

--- a/app/models/scheduled_message.rb
+++ b/app/models/scheduled_message.rb
@@ -2,6 +2,7 @@ class ScheduledMessage < ActiveRecord::Base
   validates :body, presence: true
   validates :days_after_start, presence: true
   validates :tag_list, presence: true
+  validates :time_of_day, presence: true
   validates :title, presence: true
 
   acts_as_taggable

--- a/app/models/sent_scheduled_message.rb
+++ b/app/models/sent_scheduled_message.rb
@@ -5,6 +5,7 @@ class SentScheduledMessage < ActiveRecord::Base
   validates :employee, presence: true, uniqueness: { scope: :scheduled_message }
   validates :message_body, presence: true
   validates :scheduled_message, presence: true
+  validates :sent_at, presence: true
   validates :sent_on, presence: true
 
   delegate :slack_username, to: :employee

--- a/app/services/message_employee_matcher.rb
+++ b/app/services/message_employee_matcher.rb
@@ -4,14 +4,30 @@ class MessageEmployeeMatcher
   end
 
   def run
-    Employee.where(started_on: day_count.days.ago)
+    retrieve_matching_employees
   end
 
   private
 
   attr_reader :message
 
+  def retrieve_matching_employees
+    Employee.where(started_on: day_count.days.ago)
+      .select { |employee| match_time(employee.time_zone) && message_not_already_sent?(employee) }
+  end
+
   def day_count
     message.days_after_start
+  end
+
+  def match_time(time_zone)
+    employee_current_hour = Time.current.in_time_zone(time_zone).hour
+    employee_current_minute = Time.current.in_time_zone(time_zone).min
+
+    employee_current_hour == message.time_of_day.hour && employee_current_minute == message.time_of_day.min
+  end
+
+  def message_not_already_sent?(employee)
+    SentScheduledMessage.where(employee: employee, scheduled_message: message).count == 0
   end
 end

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -55,6 +55,7 @@ class MessageSender
       employee: options[:employee],
       scheduled_message: options[:scheduled_message],
       sent_on: Date.current,
+      sent_at: Time.current,
       error_message: error_message(options[:error]),
       message_body: MessageFormatter.new(options[:scheduled_message]).escape_slack_characters
     )

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for @employee do |form| %>
   <%= form.input :slack_username %>
-  <%= form.input :started_on %>
+  <%= form.input :started_on, input_html: {class: "date-time-select"}, order: [:month, :day, :year] %>
+  <%= form.input :time_zone, priority: /US/ %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -2,6 +2,7 @@
   <tr>
     <th>Slack username</th>
     <th>Started on</th>
+    <th>Time Zone</th>
     <th></th>
     <th></th>
   </tr>
@@ -10,6 +11,7 @@
     <tr>
       <td><%= employee.slack_username %></td>
       <td><%= employee.started_on %></td>
+      <td><%= employee.time_zone %></td>
       <td><%= link_to "Edit", edit_employee_path(employee) %></td>
       <td><%= link_to "Delete",
         { action: :destroy, id: employee.id },

--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -5,6 +5,7 @@
     hint: "Don't forget, you can format your message using #{link_to "Slack's message formatting rules",
     "https://slack.zendesk.com/hc/en-us/articles/202288908-Formatting-your-messages", target: "_blank"}.".html_safe %>
   <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
+  <%= form.input :time_of_day, label: "Time of day to send message (uses employee's local time zone)", ampm: true, input_html: {class: "date-time-select"} %>
   <%= form.input :tag_list, label: "Tags", hint: "Separate tags with commas to enter multiple tags at once.", input_html: {value: @scheduled_message.tag_list.to_s} %>
   <%= form.button :submit %>
 <% end %>

--- a/app/views/scheduled_messages/index.html.erb
+++ b/app/views/scheduled_messages/index.html.erb
@@ -1,6 +1,7 @@
 <table>
   <tr>
     <th>Send day (after employee start)</th>
+    <th>Send time</th>
     <th>Title</th>
     <th>Body</th>
     <th>Tags</th>
@@ -11,6 +12,7 @@
   <% @scheduled_messages.each do |message| %>
     <tr>
       <td><%= message.days_after_start %></td>
+      <td><%= message.time_of_day.strftime("%l:%M %p") %></td>
       <td><%= message.title %></td>
       <td><%= truncate(message.body, length: 100) %></td>
       <td><%= message.tag_list.join(", ") %></td>

--- a/app/views/sent_scheduled_messages/index.html.erb
+++ b/app/views/sent_scheduled_messages/index.html.erb
@@ -2,6 +2,7 @@
   <tr>
     <th>Slack username</th>
     <th>Sent on</th>
+    <th>Sent at</th>
     <th>Message body</th>
     <th>Error message</th>
   </tr>
@@ -10,6 +11,7 @@
     <tr>
       <td><%= sent_message.slack_username %></td>
       <td><%= sent_message.sent_on %></td>
+      <td><%= display_local_time_zone(sent_message) %></td>
       <td><%= sent_message.message_body %></td>
       <td><%= sent_message.error_message %></td>
     </tr>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ Bundler.require(*Rails.groups)
 module DoloresLandinghamBot
   class Application < Rails::Application
     config.i18n.enforce_available_locales = true
+    config.time_zone = "UTC"
 
     config.generators do |generate|
       generate.helper false

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -3,7 +3,7 @@ require_relative "boot"
 require_relative "environment"
 
 module Clockwork
-  every(1.day, "scheduled_messages.send", at: "19:30", tz: "UTC") do
+  every(1.minute, "scheduled_messages.send") do
     puts "Sending scheduled messages"
     DailyMessageSender.new.delay.run
   end

--- a/db/migrate/20151021183449_add_time_zone_to_employees.rb
+++ b/db/migrate/20151021183449_add_time_zone_to_employees.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToEmployees < ActiveRecord::Migration
+  def change
+    add_column :employees, :time_zone, :string, null: false, default: "Eastern Time (US & Canada)"
+  end
+end

--- a/db/migrate/20151021194020_add_time_of_day_to_scheduled_messages.rb
+++ b/db/migrate/20151021194020_add_time_of_day_to_scheduled_messages.rb
@@ -1,0 +1,5 @@
+class AddTimeOfDayToScheduledMessages < ActiveRecord::Migration
+  def change
+    add_column :scheduled_messages, :time_of_day, :time, null: false, default: "12:00:00"
+  end
+end

--- a/db/migrate/20151021202217_add_sent_at_to_sent_scheduled_messages.rb
+++ b/db/migrate/20151021202217_add_sent_at_to_sent_scheduled_messages.rb
@@ -1,0 +1,5 @@
+class AddSentAtToSentScheduledMessages < ActiveRecord::Migration
+  def change
+    add_column :sent_scheduled_messages, :sent_at, :time, null: false, default: "12:00:00"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151006161914) do
+ActiveRecord::Schema.define(version: 20151021202217) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,28 +33,31 @@ ActiveRecord::Schema.define(version: 20151006161914) do
   add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "employees", force: :cascade do |t|
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
-    t.string   "slack_username", null: false
-    t.date     "started_on",     null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.string   "slack_username",                 null: false
+    t.date     "started_on",                     null: false
+    t.string   "time_zone",      default: "UTC", null: false
   end
 
   create_table "scheduled_messages", force: :cascade do |t|
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
-    t.string   "title",            null: false
-    t.text     "body",             null: false
-    t.integer  "days_after_start", null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.string   "title",                                            null: false
+    t.text     "body",                                             null: false
+    t.integer  "days_after_start",                                 null: false
+    t.time     "time_of_day",      default: '2000-01-01 12:00:00', null: false
   end
 
   create_table "sent_scheduled_messages", force: :cascade do |t|
-    t.datetime "created_at",                        null: false
-    t.datetime "updated_at",                        null: false
-    t.integer  "employee_id",                       null: false
-    t.string   "error_message",        default: "", null: false
-    t.text     "message_body",                      null: false
-    t.integer  "scheduled_message_id",              null: false
-    t.date     "sent_on",                           null: false
+    t.datetime "created_at",                                           null: false
+    t.datetime "updated_at",                                           null: false
+    t.integer  "employee_id",                                          null: false
+    t.string   "error_message",        default: "",                    null: false
+    t.text     "message_body",                                         null: false
+    t.integer  "scheduled_message_id",                                 null: false
+    t.date     "sent_on",                                              null: false
+    t.time     "sent_at",              default: '2000-01-01 12:00:00', null: false
   end
 
   add_index "sent_scheduled_messages", ["employee_id", "scheduled_message_id"], name: "by_employee_scheduled_message", unique: true, using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,8 +2,9 @@ FactoryGirl.define do
   sequence(:slack_username) { |n| "test_username_#{n}" }
 
   factory :employee do
-    started_on  { Date.today }
     slack_username
+    started_on  { Date.today }
+    time_zone "Eastern Time (US & Canada)"
   end
 
   factory :sent_scheduled_message do
@@ -11,12 +12,14 @@ FactoryGirl.define do
     scheduled_message
     message_body "Message body!"
     sent_on { Date.today }
+    sent_at { Time.parse("10:00:00 UTC") }
   end
 
   factory :scheduled_message do
     title "Onboarding message 1"
     body "This is an awesome message!"
     days_after_start 3
+    time_of_day { Time.parse("10:00:00 UTC") }
     tag_list "test_tag, test_tag_two"
   end
 end

--- a/spec/features/create_employees_spec.rb
+++ b/spec/features/create_employees_spec.rb
@@ -10,6 +10,7 @@ feature "Create employees" do
     select "2015", from: "employee_started_on_1i"
     select "June", from: "employee_started_on_2i"
     select "1", from: "employee_started_on_3i"
+    select "Eastern Time (US & Canada)", from: "employee_time_zone"
     click_on "Create Employee"
 
     expect(page).to have_content("Thanks for adding #{username}")
@@ -24,6 +25,7 @@ feature "Create employees" do
     select "2015", from: "employee_started_on_1i"
     select "June", from: "employee_started_on_2i"
     select "1", from: "employee_started_on_3i"
+    select "Eastern Time (US & Canada)", from: "employee_time_zone"
     click_on "Create Employee"
 
     expect(page).to have_content("There is not a slack user with the username \"#{username}\" in your organization.")

--- a/spec/features/create_scheduled_message_spec.rb
+++ b/spec/features/create_scheduled_message_spec.rb
@@ -9,6 +9,8 @@ feature "Create scheduled message" do
     fill_in "Title", with: "Message title"
     fill_in "Message body", with: "Message body"
     fill_in "Days after employee starts to send message", with: 1
+    select "11 AM", from: "scheduled_message_time_of_day_4i"
+    select "45", from: "scheduled_message_time_of_day_5i"
     fill_in "Tags", with: "tag_one, tag_two, tag_three"
     click_on "Create Scheduled message"
 

--- a/spec/features/view_employees_spec.rb
+++ b/spec/features/view_employees_spec.rb
@@ -10,8 +10,10 @@ feature "View employees" do
 
     expect(page).to have_content(first_employee.slack_username)
     expect(page).to have_content(first_employee.started_on)
+    expect(page).to have_content(first_employee.time_zone)
     expect(page).to have_content(second_employee.slack_username)
     expect(page).to have_content(second_employee.started_on)
+    expect(page).to have_content(second_employee.time_zone)
   end
 
   private

--- a/spec/features/view_scheduled_messages_spec.rb
+++ b/spec/features/view_scheduled_messages_spec.rb
@@ -10,8 +10,12 @@ feature "View scheduled messages" do
 
     expect(page).to have_content(first_scheduled_message.title)
     expect(page).to have_content(first_scheduled_message.body)
+    expect(page).to have_content(first_scheduled_message.days_after_start)
+    expect(page).to have_content(first_scheduled_message.time_of_day.strftime("%l:%M %p"))
     expect(page).to have_content(second_scheduled_message.title)
     expect(page).to have_content(second_scheduled_message.body)
+    expect(page).to have_content(second_scheduled_message.days_after_start)
+    expect(page).to have_content(second_scheduled_message.time_of_day.strftime("%l:%M %p"))
   end
 
   private

--- a/spec/helpers/format_time_zone_spec.rb
+++ b/spec/helpers/format_time_zone_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe TimeZoneDisplayHelper do
+  describe "#display_local_time_zone" do
+    it "formats for Eastern Time (US & Canada)" do
+      sent_scheduled_message = create(:sent_scheduled_message)
+
+      time_display = display_local_time_zone(sent_scheduled_message)
+
+      sent_scheduled_message.sent_at.in_time_zone(sent_scheduled_message.employee.time_zone).dst? ?
+        expected_time_display = "6:00 AM (EDT)" :
+        expected_time_display = "5:00 AM (EST)"
+
+      expect(time_display).to eq(expected_time_display)
+    end
+
+    it "formats for Central Time (US & Canada)" do
+      employee = create(:employee, time_zone: "Central Time (US & Canada)")
+      sent_scheduled_message = create(:sent_scheduled_message, employee: employee)
+
+      time_display = display_local_time_zone(sent_scheduled_message)
+
+      sent_scheduled_message.sent_at.in_time_zone(sent_scheduled_message.employee.time_zone).dst? ?
+        expected_time_display = "5:00 AM (CDT)" :
+        expected_time_display = "4:00 AM (CST)"
+
+      expect(time_display).to eq(expected_time_display)
+    end
+
+    it "formats for Mountain Time (US & Canada)" do
+      employee = create(:employee, time_zone: "Mountain Time (US & Canada)")
+      sent_scheduled_message = create(:sent_scheduled_message, employee: employee)
+
+      time_display = display_local_time_zone(sent_scheduled_message)
+
+      sent_scheduled_message.sent_at.in_time_zone(sent_scheduled_message.employee.time_zone).dst? ?
+        expected_time_display = "4:00 AM (MDT)" :
+        expected_time_display = "3:00 AM (MST)"
+
+      expect(time_display).to eq(expected_time_display)
+    end
+
+    it "formats for Pacific Time (US & Canada)" do
+      employee = create(:employee, time_zone: "Pacific Time (US & Canada)")
+      sent_scheduled_message = create(:sent_scheduled_message, employee: employee)
+
+      time_display = display_local_time_zone(sent_scheduled_message)
+
+      sent_scheduled_message.sent_at.in_time_zone(sent_scheduled_message.employee.time_zone).dst? ?
+        expected_time_display = "3:00 AM (PDT)" :
+        expected_time_display = "2:00 AM (PST)"
+
+      expect(time_display).to eq(expected_time_display)
+    end
+  end
+end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -8,5 +8,6 @@ describe Employee do
      it { should allow_value("test_user_1").for(:slack_username) }
      it { should_not allow_value("TEST USER 1").for(:slack_username) }
      it { should validate_presence_of(:started_on) }
+     it { should validate_presence_of(:time_zone) }
   end
 end

--- a/spec/models/scheduled_message_spec.rb
+++ b/spec/models/scheduled_message_spec.rb
@@ -5,6 +5,7 @@ describe ScheduledMessage do
      it { should validate_presence_of(:body) }
      it { should validate_presence_of(:days_after_start) }
      it { should validate_presence_of(:tag_list) }
+     it { should validate_presence_of(:time_of_day) }
      it { should validate_presence_of(:title) }
   end
 end

--- a/spec/models/sent_scheduled_message_spec.rb
+++ b/spec/models/sent_scheduled_message_spec.rb
@@ -10,6 +10,7 @@ describe SentScheduledMessage do
     it { should validate_presence_of(:employee) }
     it { should validate_presence_of(:message_body) }
     it { should validate_presence_of(:scheduled_message) }
+    it { should validate_presence_of(:sent_at) }
     it { should validate_presence_of(:sent_on) }
 
     it "validates employee uniqueness scoped to scheduled message" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 ENV["RAILS_ENV"] = "test"
+ENV["TZ"] = "UTC"
 
 require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]

--- a/spec/services/employee_finder_spec.rb
+++ b/spec/services/employee_finder_spec.rb
@@ -17,7 +17,7 @@ describe EmployeeFinder do
       expect(employee_finder).to be_existing_employee
     end
 
-    it "rreturns false if an employee does not exist in the Slack organization associated with the auth token" do
+    it "returns false if an employee does not exist in the Slack organization associated with the auth token" do
       employee = create(:employee)
       client_double = Slack::Web::Client.new
       existing_user_double = double(existing_user?: false)

--- a/spec/services/message_employee_matcher_spec.rb
+++ b/spec/services/message_employee_matcher_spec.rb
@@ -3,17 +3,49 @@ require "rails_helper"
 describe MessageEmployeeMatcher do
   describe "#run" do
     it "matches messages to users based on days after start" do
+      Timecop.freeze(Time.current)
+
       days_after_start = 3
-      scheduled_message = create(:scheduled_message, days_after_start: days_after_start)
-      _other_message = create(:scheduled_message, days_after_start: 2)
-      employee_for_scheduled_message = create(:employee, started_on: days_after_start.days.ago)
-      _other_employee = create(:employee, started_on: Date.today)
+      scheduled_message = create(:scheduled_message, days_after_start: days_after_start, time_of_day: Time.current.in_time_zone("Eastern Time (US & Canada)"))
+      employee = create(:employee, started_on: days_after_start.days.ago)
 
       matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
 
       expect(matched_employees_and_messages).to eq(
-          [ employee_for_scheduled_message ]
+          [ employee ]
       )
+
+      Timecop.return
+    end
+
+    it "ignores messages that have already been sent to users" do
+      Timecop.freeze(Time.current)
+
+      days_after_start = 3
+      scheduled_message = create(:scheduled_message, days_after_start: days_after_start, time_of_day: Time.current.in_time_zone("Eastern Time (US & Canada)"))
+      employee_one = create(:employee, started_on: days_after_start.days.ago)
+      employee_two = create(:employee, started_on: days_after_start.days.ago)
+      client_double = Slack::Web::Client.new
+      slack_channel_id = "fake_slack_channel_id"
+      slack_channel_finder_double = double(run: slack_channel_id)
+
+      allow(Slack::Web::Client).to receive(:new).and_return(client_double)
+      allow(SlackChannelIdFinder).
+        to receive(:new).with(employee_one.slack_username, client_double).
+        and_return(slack_channel_finder_double)
+
+      pre_matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
+      MessageSender.new(employee_one, scheduled_message).run
+      post_matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
+
+      expect(pre_matched_employees_and_messages).to eq(
+          [ employee_one, employee_two ]
+      )
+      expect(post_matched_employees_and_messages).to eq(
+          [ employee_two ]
+      )
+
+      Timecop.return
     end
   end
 end

--- a/spec/services/message_sender_spec.rb
+++ b/spec/services/message_sender_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 describe MessageSender do
   it "creates a sent scheduled message if sent successfully" do
+    Timecop.freeze(Time.parse("10:00:00 UTC"))
+
     scheduled_message = create(:scheduled_message)
     employee = create(:employee)
     client_double = Slack::Web::Client.new
@@ -14,19 +16,23 @@ describe MessageSender do
       and_return(slack_channel_finder_double)
     allow(SentScheduledMessage).to receive(:create)
 
-
     MessageSender.new(employee, scheduled_message).run
 
     expect(SentScheduledMessage).to have_received(:create).with(
       employee: employee,
       scheduled_message: scheduled_message,
-      sent_on: Date.current,
+      sent_on: Date.today,
+      sent_at: Time.parse("10:00:00 UTC"),
       error_message: "",
       message_body: scheduled_message.body,
     )
+
+    Timecop.return
   end
 
   it "creates a sent scheduled message with error message if error" do
+    Timecop.freeze(Time.parse("10:00:00 UTC"))
+
     scheduled_message = create(:scheduled_message)
     employee = create(:employee)
     client_double = Slack::Web::Client.new
@@ -40,19 +46,23 @@ describe MessageSender do
       and_return(slack_channel_finder_double)
     allow(SentScheduledMessage).to receive(:create)
 
-
     MessageSender.new(employee, scheduled_message).run
 
     expect(SentScheduledMessage).to have_received(:create).with(
       employee: employee,
       error_message: "not_authed",
       scheduled_message: scheduled_message,
-      sent_on: Date.current,
+      sent_on: Date.today,
+      sent_at: Time.parse("10:00:00 UTC"),
       message_body: scheduled_message.body,
     )
+
+    Timecop.return
   end
 
   it "does not error if channel not found for slack user" do
+    Timecop.freeze(Time.parse("10:00:00 UTC"))
+
     scheduled_message = create(:scheduled_message)
     employee = create(:employee)
     client_double = Slack::Web::Client.new
@@ -67,5 +77,7 @@ describe MessageSender do
     MessageSender.new(employee, scheduled_message).run
 
     expect(SentScheduledMessage).not_to have_received(:create)
+
+    Timecop.return
   end
 end


### PR DESCRIPTION
This changeset adds support for specific times to be set for scheduled messages and for setting time zones for employees.  The combination of these two things now allows an administrator to set scheduled messages to go out at specific times, e.g., 10:00 AM, and those messages well be sent respective to each employee's local time (meaning the message will be sent to an EST employee at 10 AM EST, and to a PST employee at 10 AM PST).