### PR TITLE
Connects #97:  Fixes an issue when checking employee local times against the time a scheduled message should be sent.

### DIFF
--- a/app/services/message_employee_matcher.rb
+++ b/app/services/message_employee_matcher.rb
@@ -21,10 +21,9 @@ class MessageEmployeeMatcher
   end
 
   def match_time(time_zone)
-    employee_current_hour = Time.current.in_time_zone(time_zone).hour
-    employee_current_minute = Time.current.in_time_zone(time_zone).min
+    employee_current_time = Time.current.in_time_zone(time_zone)
 
-    employee_current_hour == message.time_of_day.hour && employee_current_minute == message.time_of_day.min
+    employee_current_time.utc.strftime("%H%M%S%N") >= message.time_of_day.utc.strftime("%H%M%S%N")
   end
 
   def message_not_already_sent?(employee)

--- a/spec/services/message_employee_matcher_spec.rb
+++ b/spec/services/message_employee_matcher_spec.rb
@@ -3,49 +3,62 @@ require "rails_helper"
 describe MessageEmployeeMatcher do
   describe "#run" do
     it "matches messages to users based on days after start" do
-      Timecop.freeze(Time.current)
+      Timecop.freeze(Time.current) do
+        days_after_start = 3
+        scheduled_message = create(:scheduled_message, days_after_start: days_after_start, time_of_day: Time.current.in_time_zone("Eastern Time (US & Canada)"))
+        employee = create(:employee, started_on: days_after_start.days.ago)
 
-      days_after_start = 3
-      scheduled_message = create(:scheduled_message, days_after_start: days_after_start, time_of_day: Time.current.in_time_zone("Eastern Time (US & Canada)"))
-      employee = create(:employee, started_on: days_after_start.days.ago)
+        matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
 
-      matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
+        expect(matched_employees_and_messages).to eq(
+            [ employee ]
+        )
+      end
+    end
 
-      expect(matched_employees_and_messages).to eq(
-          [ employee ]
-      )
+    it "matches messages to users if the user's time has advanced past the scheduled message send at time but hasn't been sent yet" do
+      Timecop.freeze(Time.current) do
+        days_after_start = 3
+        half_hour_time_difference_in_seconds = 1800
+        scheduled_message_time = Time.current.in_time_zone("Eastern Time (US & Canada)")
+        scheduled_message_time = scheduled_message_time - half_hour_time_difference_in_seconds
+        scheduled_message = create(:scheduled_message, days_after_start: days_after_start, time_of_day: scheduled_message_time)
+        employee = create(:employee, started_on: days_after_start.days.ago)
 
-      Timecop.return
+        matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
+
+        expect(matched_employees_and_messages).to eq(
+            [ employee ]
+        )
+      end
     end
 
     it "ignores messages that have already been sent to users" do
-      Timecop.freeze(Time.current)
+      Timecop.freeze(Time.current) do
+        days_after_start = 3
+        scheduled_message = create(:scheduled_message, days_after_start: days_after_start, time_of_day: Time.current.in_time_zone("Eastern Time (US & Canada)"))
+        employee_one = create(:employee, started_on: days_after_start.days.ago)
+        employee_two = create(:employee, started_on: days_after_start.days.ago)
+        client_double = Slack::Web::Client.new
+        slack_channel_id = "fake_slack_channel_id"
+        slack_channel_finder_double = double(run: slack_channel_id)
 
-      days_after_start = 3
-      scheduled_message = create(:scheduled_message, days_after_start: days_after_start, time_of_day: Time.current.in_time_zone("Eastern Time (US & Canada)"))
-      employee_one = create(:employee, started_on: days_after_start.days.ago)
-      employee_two = create(:employee, started_on: days_after_start.days.ago)
-      client_double = Slack::Web::Client.new
-      slack_channel_id = "fake_slack_channel_id"
-      slack_channel_finder_double = double(run: slack_channel_id)
+        allow(Slack::Web::Client).to receive(:new).and_return(client_double)
+        allow(SlackChannelIdFinder).
+          to receive(:new).with(employee_one.slack_username, client_double).
+          and_return(slack_channel_finder_double)
 
-      allow(Slack::Web::Client).to receive(:new).and_return(client_double)
-      allow(SlackChannelIdFinder).
-        to receive(:new).with(employee_one.slack_username, client_double).
-        and_return(slack_channel_finder_double)
+        pre_matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
+        MessageSender.new(employee_one, scheduled_message).run
+        post_matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
 
-      pre_matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
-      MessageSender.new(employee_one, scheduled_message).run
-      post_matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run
-
-      expect(pre_matched_employees_and_messages).to eq(
-          [ employee_one, employee_two ]
-      )
-      expect(post_matched_employees_and_messages).to eq(
-          [ employee_two ]
-      )
-
-      Timecop.return
+        expect(pre_matched_employees_and_messages).to eq(
+            [ employee_one, employee_two ]
+        )
+        expect(post_matched_employees_and_messages).to eq(
+            [ employee_two ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
This changeset addresses an issue that could potentially prevent a message from being sent if the local time of a user does not exactly match (by the hour and minute) the time a scheduled message is set to be sent out.  This adjustment changes the check to look for a match at the current time or any time thereafter.  A separate check is already in place that ensures the message has not already been sent to the employee.