### PR TITLE
Connects #100:  Fixes issue with messages sent at the wrong time.

### DIFF
--- a/app/services/message_employee_matcher.rb
+++ b/app/services/message_employee_matcher.rb
@@ -22,8 +22,10 @@ class MessageEmployeeMatcher
 
   def match_time(time_zone)
     employee_current_time = Time.current.in_time_zone(time_zone)
+    employee_current_time_string = employee_current_time.strftime("%H%M%S%N")
+    message_time_string = message.time_of_day.strftime("%H%M%S%N")
 
-    employee_current_time.utc.strftime("%H%M%S%N") >= message.time_of_day.utc.strftime("%H%M%S%N")
+    employee_current_time_string >= message_time_string
   end
 
   def message_not_already_sent?(employee)


### PR DESCRIPTION
The changeset introduced to fix issue #97 had another problem with it in that the time check between the current time of the employee and the time the scheduled message was supposed to go out was still incorrect.  This changeset fixes the time comparison check and bolsters the tests to account for this situation.