### PR TITLE
Connects #38:  Add pagination to index pages.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "daemons" # for delayed_job
 gem "delayed_job_active_record"
 gem "foreman"
 gem "jquery-rails"
+gem "kaminari"
 gem "omniauth-myusa", github: "18f/omniauth-myusa"
 gem "pg"
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,9 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.1)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -267,6 +270,7 @@ DEPENDENCIES
   factory_girl_rails
   foreman
   jquery-rails
+  kaminari
   omniauth-myusa!
   pg
   pry-rails

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -20,7 +20,7 @@ class EmployeesController < ApplicationController
   end
 
   def index
-    @employees = Employee.order(started_on: :desc)
+    @employees = Employee.order(started_on: :desc).page(params[:page])
   end
 
   def edit

--- a/app/controllers/scheduled_messages_controller.rb
+++ b/app/controllers/scheduled_messages_controller.rb
@@ -16,7 +16,7 @@ class ScheduledMessagesController < ApplicationController
   end
 
   def index
-    @scheduled_messages = ScheduledMessage.order(:days_after_start)
+    @scheduled_messages = ScheduledMessage.order(:days_after_start).page(params[:page])
   end
 
   def edit

--- a/app/controllers/sent_scheduled_messages_controller.rb
+++ b/app/controllers/sent_scheduled_messages_controller.rb
@@ -1,5 +1,5 @@
 class SentScheduledMessagesController < ApplicationController
   def index
-    @sent_scheduled_messages = SentScheduledMessage.order(sent_on: :desc)
+    @sent_scheduled_messages = SentScheduledMessage.order(sent_on: :desc).page(params[:page])
   end
 end

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -21,3 +21,5 @@
     </tr>
   <% end %>
 </table>
+
+<%= paginate(@employees) %>

--- a/app/views/scheduled_messages/index.html.erb
+++ b/app/views/scheduled_messages/index.html.erb
@@ -21,3 +21,5 @@
     </tr>
   <% end %>
 </table>
+
+<%= paginate(@scheduled_messages) %>

--- a/app/views/sent_scheduled_messages/index.html.erb
+++ b/app/views/sent_scheduled_messages/index.html.erb
@@ -12,8 +12,10 @@
       <td><%= sent_message.slack_username %></td>
       <td><%= sent_message.sent_on %></td>
       <td><%= display_local_time_zone(sent_message) %></td>
-      <td><%= sent_message.message_body %></td>
+      <td><%= truncate(sent_message.message_body, length: 25, separator: ' ') %></td>
       <td><%= sent_message.error_message %></td>
     </tr>
   <% end %>
 <table>
+
+<%= paginate(@sent_scheduled_messages) %>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,10 @@
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  config.max_per_page = nil
+  config.window = 4
+  config.outer_window = 0
+  config.left = 0
+  config.right = 0
+  config.page_method_name = :page
+  config.param_name = :page
+end

--- a/spec/features/view_scheduled_messages_spec.rb
+++ b/spec/features/view_scheduled_messages_spec.rb
@@ -18,6 +18,38 @@ feature "View scheduled messages" do
     expect(page).to have_content(second_scheduled_message.time_of_day.strftime("%l:%M %p"))
   end
 
+  scenario "sees pagination controls" do
+    allow(Kaminari.config).to receive(:default_per_page).and_return(1)
+
+    login_with_oauth
+    visit root_path
+    create_scheduled_messages
+
+    click_on "See and/or edit scheduled messages"
+
+    expect(page).to have_content(first_scheduled_message.title)
+    expect(page).to have_content(first_scheduled_message.body)
+    expect(page).to have_content(first_scheduled_message.days_after_start)
+    expect(page).to have_content(first_scheduled_message.time_of_day.strftime("%l:%M %p"))
+
+    expect(page).not_to have_content(second_scheduled_message.title)
+
+    expect(page).to have_content("Next")
+    expect(page).to have_content("Last")
+
+    click_on "Last"
+
+    expect(page).not_to have_content(first_scheduled_message.title)
+
+    expect(page).to have_content(second_scheduled_message.title)
+    expect(page).to have_content(second_scheduled_message.body)
+    expect(page).to have_content(second_scheduled_message.days_after_start)
+    expect(page).to have_content(second_scheduled_message.time_of_day.strftime("%l:%M %p"))
+
+    expect(page).to have_content("Prev")
+    expect(page).to have_content("First")
+  end
+
   private
 
   def create_scheduled_messages
@@ -30,6 +62,6 @@ feature "View scheduled messages" do
   end
 
   def second_scheduled_message
-    @second_scheduled_message ||= create(:scheduled_message)
+    @second_scheduled_message ||= create(:scheduled_message, title: 'Onboarding message 2')
   end
 end


### PR DESCRIPTION
This changeset adds support for pagination on all of the index pages.  It also truncates the message body on the sent scheduled messages listing to help with the display of the page.