### PR TITLE
Connects #104:  Add diagnostic page for time and time zone info.

### DIFF
--- a/app/controllers/diagnostics_controller.rb
+++ b/app/controllers/diagnostics_controller.rb
@@ -1,0 +1,16 @@
+class DiagnosticsController < ApplicationController
+  def index
+    @time_diagnostics = {
+      application: {
+        current_time: Time.current.strftime("%l:%M:%S %p (%Z %z)"),
+        time_zone: Rails.application.config.time_zone,
+        clockwork_time_zone: Clockwork.manager.config[:tz]
+      },
+      server: {
+        tz_env_var: ENV["TZ"],
+        current_time: Time.now.strftime("%l:%M:%S %p (%Z %z)"),
+        time_zone: Time.now.zone
+      }
+    }
+  end
+end

--- a/app/services/message_employee_matcher.rb
+++ b/app/services/message_employee_matcher.rb
@@ -22,10 +22,10 @@ class MessageEmployeeMatcher
 
   def match_time(time_zone)
     employee_current_time = Time.current.in_time_zone(time_zone)
-    employee_current_time_string = employee_current_time.strftime("%H%M%S%N")
-    message_time_string = message.time_of_day.strftime("%H%M%S%N")
+    employee_current_time_value = employee_current_time.strftime("%H%M").to_i
+    message_time_value = message.time_of_day.strftime("%H%M").to_i
 
-    employee_current_time_string >= message_time_string
+    employee_current_time_value >= message_time_value
   end
 
   def message_not_already_sent?(employee)

--- a/app/views/diagnostics/index.html.erb
+++ b/app/views/diagnostics/index.html.erb
@@ -1,0 +1,19 @@
+<h1>Application Diagnostics</h1>
+
+<h2>Application Information</h2>
+
+<ul>
+    <li>Current Time: <%= @time_diagnostics[:application][:current_time] %></li>
+    <li>Default Time Zone: <%= @time_diagnostics[:application][:time_zone] %></li>
+    <li>Clockwork Default Time Zone: <%= @time_diagnostics[:application][:clockwork_time_zone] %></li>
+</ul>
+
+<br />
+
+<h2>Server Information</h2>
+
+<ul>
+    <li>TZ Environment Variable: <%= @time_diagnostics[:server][:tz_env_var] %></li>
+    <li>Server Time: <%= @time_diagnostics[:server][:current_time] %></li>
+    <li>Time Zone: <%= @time_diagnostics[:server][:time_zone] %></li>
+</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,17 +17,19 @@
 
   <h1>Dolores Landingham</h1>
     <%= image_tag "logo-18f.png", class: "logo-18f" %><p>Onboarding bot!</p>
-  <hr>
+  <hr />
     <%= link_to "Create scheduled message", new_scheduled_message_path %>
-  <hr>
+  <hr />
     <%= link_to "See and/or edit scheduled messages", scheduled_messages_path %>
-  <hr>
+  <hr />
     <%= link_to "Add an employee", new_employee_path %>
-  <hr>
+  <hr />
     <%= link_to "See all employees", employees_path %>
-  <hr>
+  <hr />
     <%= link_to "See sent scheduled messages", sent_scheduled_messages_path %>
-  <hr>
+  <hr />
+    <%= link_to "View application diagnostics", diagnostics_path %>
+  <hr />
 </div>
 <%= render "flashes" -%>
 <div class="content">

--- a/app/views/sent_scheduled_messages/index.html.erb
+++ b/app/views/sent_scheduled_messages/index.html.erb
@@ -12,7 +12,7 @@
       <td><%= sent_message.slack_username %></td>
       <td><%= sent_message.sent_on %></td>
       <td><%= display_local_time_zone(sent_message) %></td>
-      <td><%= truncate(sent_message.message_body, length: 25, separator: ' ') %></td>
+      <td><%= truncate(sent_message.message_body, length: 50, separator: ' ') %></td>
       <td><%= sent_message.error_message %></td>
     </tr>
   <% end %>

--- a/config/initializers/clockwork_config.rb
+++ b/config/initializers/clockwork_config.rb
@@ -1,0 +1,5 @@
+module Clockwork
+  configure do |config|
+    config[:tz] = "UTC"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   match "/auth/:provider/callback" => "auth#oauth_callback", via: [:get]
 
+  resources :diagnostics, only: [:index]
   resources :employees, only: [:new, :create, :index, :edit, :update, :destroy]
   resources :sent_scheduled_messages, only: [:index]
   resources :scheduled_messages, only: [:new, :create, :index, :edit, :update] do


### PR DESCRIPTION
This changeset adds a diagnostics page that displays application and server information regarding the current time and time zone settings.  It also slightly modifies the time check for matching messages to employees to be a bit more explicit and adds a Clockwork default time zone configuration for UTC.  The hope is that with these changes and additional information being exposed we can finally uncover why the scheduled messages have been sent out at the wrong time.