### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+before_install:
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+before_script:
+- cp .sample.env .env
+- bin/rake db:setup --trace
+bundler_args: "--deployment --jobs=3 --retry=3 --without development"
+cache: bundler
+env:
+- DB=postgresql
+language: ruby
+rvm:
+- ruby-2.2.3
+sudo: false
+script:
+- bundle exec rake


### PR DESCRIPTION
**Why**:
So that the tests can be run automatically on a continuous integration service.

Note that someone with admin rights to the repo needs to turn on the repo here: https://travis-ci.org/profile/18F

Closes #47.