### PR TITLE
Fixed sent messages filter, re-introduced pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "slack-ruby-client"
 gem "uglifier"
 gem "business_time"
 gem "holidays"
+gem "active_record_union"
 
 group :development, :test do
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
     activejob (4.2.5.1)
       activesupport (= 4.2.5.1)
+    active_record_union (1.1.0)
+      activerecord (>= 4.0)
       globalid (>= 0.3.0)
     activemodel (4.2.5.1)
       activesupport (= 4.2.5.1)
@@ -265,6 +267,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_record_union
   acts-as-taggable-on
   awesome_print
   bundler-audit

--- a/app/assets/stylesheets/sass/_filter.scss
+++ b/app/assets/stylesheets/sass/_filter.scss
@@ -6,13 +6,13 @@
 
 .filter-area {
   background: white;
-  padding-top: 1em;
   top: 0;
   width: 100%;
 
   &.fixedsticky-on {
     border-bottom: 1px solid $gray-mid;
     padding-bottom: 1em;
+    padding-top: 1em;
   }
 }
 

--- a/app/assets/stylesheets/sass/core.scss
+++ b/app/assets/stylesheets/sass/core.scss
@@ -8,7 +8,7 @@
 @import "content";
 @import "utils";
 @import "alert";
-@import "custom";
+@import "filter";
 
 .container {
 	@include outer-container;

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -24,9 +24,9 @@ class EmployeesController < ApplicationController
 
   def index
     if params[:slack_username].present? || params[:started_on].present?
-      @employees = Employee.filter(params).order(slack_username: :asc)
+      @employees = Employee.filter(params).order(slack_username: :asc).page(params[:page])
     else
-      @employees = Employee.order(started_on: :desc).page(params[:page])
+      @employees = Employee.order(created_at: :desc).page(params[:page])
     end
   end
 

--- a/app/controllers/scheduled_messages_controller.rb
+++ b/app/controllers/scheduled_messages_controller.rb
@@ -16,7 +16,7 @@ class ScheduledMessagesController < ApplicationController
   end
 
   def index
-    @scheduled_messages = ScheduledMessage.filter(params).order(:days_after_start)
+    @scheduled_messages = ScheduledMessage.filter(params).order(:days_after_start).page(params[:page])
   end
 
   def edit

--- a/app/controllers/sent_scheduled_messages_controller.rb
+++ b/app/controllers/sent_scheduled_messages_controller.rb
@@ -1,5 +1,5 @@
 class SentScheduledMessagesController < ApplicationController
   def index
-    @sent_scheduled_messages = SentScheduledMessage.filter(params).order(sent_on: :desc)
+    @sent_scheduled_messages = SentScheduledMessage.filter(params).order(created_at: :desc).page(params[:page])
   end
 end

--- a/app/views/employees/index.html.erb
+++ b/app/views/employees/index.html.erb
@@ -1,5 +1,5 @@
 <header class="filter-area">
-  <h3>Filter by</h3>
+  <h2>Filter</h2>
   <%= form_tag(employees_path, method: "get", class: "navbar-form") do %>
     <div class="input-append">
       <%= text_field_tag :slack_username, params[:slack_username], class: "filter-input", placeholder: "slack username" %>
@@ -32,7 +32,9 @@
     </tr>
   <% end %>
 </table>
-<% if @employees.count == 0 %>
+<% if @employees.empty? %>
   <label>No matches found.</label>
 <% end %>
+
+<%= paginate(@employees) %>
 

--- a/app/views/scheduled_messages/_form.html.erb
+++ b/app/views/scheduled_messages/_form.html.erb
@@ -4,7 +4,7 @@
   <%= form.input :body, label: "Message body",
     hint: "Don't forget, you can format your message using #{link_to "Slack's message formatting rules",
     "https://slack.zendesk.com/hc/en-us/articles/202288908-Formatting-your-messages", target: "_blank"}.".html_safe %>
-  <%= form.input :days_after_start, label: "Days after employee starts to send message" %>
+  <%= form.input :days_after_start, label: "Business days after employee starts to send message" %>
   <%= form.input :time_of_day, label: "Time of day to send message (uses employee's local time zone)", ampm: true, input_html: {class: "date-time-select"} %>
   <%= form.input :tag_list, label: "Tags", hint: "Separate tags with commas to enter multiple tags at once.", input_html: {value: @scheduled_message.tag_list.to_s} %>
   <%= form.button :submit %>

--- a/app/views/scheduled_messages/index.html.erb
+++ b/app/views/scheduled_messages/index.html.erb
@@ -1,5 +1,6 @@
 <header class="filter-area">
-  <h3>Filter by<label><i>Please separate tags with a comma</i></label></h3>
+  <h2>Filter</h2>
+  <label><i>Please separate tags with a comma</i></label>
   <%= form_tag(scheduled_messages_path, method: "get", class: "navbar-form", slack_username: "search-form") do %>
     <div class="input-append">
       <%= text_field_tag :title, params[:title], class: "filter-input", placeholder: "title" %>
@@ -13,7 +14,7 @@
 
 <table>
   <tr>
-    <th>Send day (after employee start)</th>
+    <th>Send day (business days after employee start)</th>
     <th>Send time</th>
     <th>Title</th>
     <th>Body</th>
@@ -34,6 +35,8 @@
     </tr>
   <% end %>
 </table>
-<% if @scheduled_messages.count == 0 %>
+<% if @scheduled_messages.empty? %>
   <label>No matches found.</label>
 <% end %>
+
+<%= paginate(@scheduled_messages) %>

--- a/app/views/sent_scheduled_messages/index.html.erb
+++ b/app/views/sent_scheduled_messages/index.html.erb
@@ -1,5 +1,5 @@
 <header class="filter-area">
-  <h3>Filter by</h3>
+  <h2>Filter</h2>
   <%= form_tag(sent_scheduled_messages_path, method: "get", class: "navbar-form", slack_username: "search-form") do %>
     <div class="input-append">
       <%= text_field_tag :slack_username, params[:slack_username], class: "filter-input", placeholder: "slack username" %>
@@ -31,6 +31,8 @@
     </tr>
   <% end %>
 <table>
-<% if @sent_scheduled_messages.count == 0 %>
+<% if @sent_scheduled_messages.empty? %>
   <label>No matches found.</label>
 <% end %>
+
+<%= paginate(@sent_scheduled_messages) %>

--- a/spec/features/create_scheduled_message_spec.rb
+++ b/spec/features/create_scheduled_message_spec.rb
@@ -8,7 +8,7 @@ feature "Create scheduled message" do
 
     fill_in "Title", with: "Message title"
     fill_in "Message body", with: "Message body"
-    fill_in "Days after employee starts to send message", with: 1
+    fill_in "Business days after employee starts to send message", with: 1
     select "11 AM", from: "scheduled_message_time_of_day_4i"
     select "45", from: "scheduled_message_time_of_day_5i"
     fill_in "Tags", with: "tag_one, tag_two, tag_three"
@@ -23,7 +23,7 @@ feature "Create scheduled message" do
     click_on "Create scheduled message"
 
     fill_in "Title", with: "Message title"
-    fill_in "Days after employee starts to send message", with: 1
+    fill_in "Business days after employee starts to send message", with: 1
     click_on "Create Scheduled message"
 
     expect(page).to have_content("Could not create scheduled message")

--- a/spec/features/view_scheduled_messages_spec.rb
+++ b/spec/features/view_scheduled_messages_spec.rb
@@ -19,6 +19,8 @@ feature "View scheduled messages" do
   end
 
   scenario "sees pagination controls" do
+    allow(Kaminari.config).to receive(:default_per_page).and_return(1)
+
     login_with_oauth
     visit root_path
     create_scheduled_messages
@@ -30,11 +32,22 @@ feature "View scheduled messages" do
     expect(page).to have_content(first_scheduled_message.days_after_start)
     expect(page).to have_content(first_scheduled_message.time_of_day.strftime("%l:%M %p"))
 
+    expect(page).not_to have_content(second_scheduled_message.title)
+
+    expect(page).to have_content("Next")
+    expect(page).to have_content("Last")
+
+    click_on "Last"
+
+    expect(page).not_to have_content(first_scheduled_message.title)
+
     expect(page).to have_content(second_scheduled_message.title)
     expect(page).to have_content(second_scheduled_message.body)
     expect(page).to have_content(second_scheduled_message.days_after_start)
     expect(page).to have_content(second_scheduled_message.time_of_day.strftime("%l:%M %p"))
 
+    expect(page).to have_content("Prev")
+    expect(page).to have_content("First")
   end
 
   private


### PR DESCRIPTION
Fixes #137 

This PR
* fixes the SentScheduledMessages filter
* re-introduces pagination, ordering with unique keys, per [Moncef's comment](https://github.com/18F/dolores-landingham-bot/issues/128#issuecomment-171047847)
 
@jessieay or @ccostino once the test pass, care to review?