### PR TITLE
Fix cf-ssh adapter issue

### DIFF
--- a/cf-ssh.yml
+++ b/cf-ssh.yml
@@ -13,5 +13,7 @@ applications:
   memory: 1GB
   name: dolores-app-ssh
   no-route: true
+  services:
+  - dolores-app-db
 command: script/start
 domain: 18f.gov

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,10 +11,11 @@ applications:
     DEFAULT_URL_HOST: dolores-app.18f.gov
     HOST: dolores-app.18f.gov
     APPLICATION_HOST: dolores-app.18f.gov
-    DISABLE_SANDBOX_WARNING: true
     RESTRICT_ACCESS: true
     RACK_ENV: production
     RAILS_ENV: production
+  services:
+    - dolores-app-db
 - name: dolores-staging
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
   memory: 1GB
@@ -22,7 +23,8 @@ applications:
     DEFAULT_URL_HOST: dolores-staging.18f.gov
     HOST: dolores-staging.18f.gov
     APPLICATION_HOST: dolores-staging.18f.gov
-    DISABLE_SANDBOX_WARNING: true
     RESTRICT_ACCESS: true
     RACK_ENV: production
     RAILS_ENV: production
+  services:
+    - dolores-staging-db


### PR DESCRIPTION
This is a PR without a connected issue. 

I had consistently been having issues running the `cf-ssh` command to access the database for `dolores-app`. I had been receiving the following error:

```ActiveRecord::AdapterNotSpecified: database configuration does not specify adapter``` 

Diego explained to me that this is because we need to have the services (postgres database instance) that we are using for the app defined in the manifest file and not as a cloud foundry environment variable. 

I made the change and it fixed the issue. @jessieay @ccostino Looking for either of your blessing!