### PR TITLE
[WIP] Connects #72:  Adds employee import functionality

### DIFF
--- a/app/services/employee_importer.rb
+++ b/app/services/employee_importer.rb
@@ -1,0 +1,61 @@
+require "slack-ruby-client"
+
+class EmployeeImporter
+  def initialize
+    configure_slack
+  end
+
+  def import(dry_run = false)
+    import_results = {created: 0, skipped: 0, dry_run: false}
+    slack_user_importer = SlackUserImporter.new("", client)
+    total_employees = slack_user_importer.slack_usernames.count
+
+    slack_user_importer.slack_usernames.each_with_index do |slack_username, index|
+      if !dry_run
+        success = import_employee(slack_username)
+      else
+        success = dry_import_employee(slack_username)
+        import_results[:dry_run] = true
+      end
+
+      if success
+        Rails.logger.info "#{index + 1}/#{total_employees}: Created #{slack_username}#{" (dry run)" if dry_run}".green
+        import_results[:created] += 1
+      else
+        Rails.logger.info "#{index + 1}/#{total_employees}: Skipped #{slack_username}#{" (dry run)" if dry_run}".yellow
+        import_results[:skipped] += 1
+      end
+    end
+
+    import_results
+  end
+
+  private
+
+  def client
+    @client ||= Slack::Web::Client.new
+  end
+
+  def configure_slack
+    Slack.configure do |config|
+      config.token = ENV['SLACK_API_TOKEN']
+    end
+  end
+
+  def dry_import_employee(slack_username)
+    Employee.where(slack_username: slack_username).size == 0
+  end
+
+  def import_employee(slack_username)
+    # TODO:  Once we can hook up the Team API, we'll want to grab the start
+    # TODO:  date of an employee from there instead of defaulting to the
+    # TODO:  current date and time.
+
+    # TODO:  We'll also want to verify that the Slack user is an actual person
+    # TODO:  Against the Team API - Slack alone cannot tell us if they are real
+    # TODO:  or not.
+
+    employee = Employee.new(slack_username: slack_username, started_on: Time.now)
+    employee.save
+  end
+end

--- a/app/services/slack_user_importer.rb
+++ b/app/services/slack_user_importer.rb
@@ -1,0 +1,5 @@
+class SlackUserImporter < SlackApiWrapper
+  def slack_usernames
+    all_slack_users.map { |slack_user| slack_user["name"] }
+  end
+end

--- a/lib/tasks/employees.rake
+++ b/lib/tasks/employees.rake
@@ -1,0 +1,41 @@
+namespace :employees do
+  desc "Imports all employees from Slack into the Dolores Landingham bot."
+  task import: :environment do
+    logger = ActiveSupport::Logger.new('log/employees_import.log')
+    start_time = Time.now
+
+    logger.info "Employee import task started at #{start_time}."
+
+    import_statistics = EmployeeImporter.new.import
+
+    end_time = Time.now
+    duration = (start_time - end_time) / 1.seconds
+
+    logger.info "Employee import task finished at #{end_time} (#{duration} seconds running time)."
+    logger.info "Employees imported: #{import_statistics[:created]}"
+    logger.info "Employees skipped: #{import_statistics[:skipped]}"
+
+    logger.close
+  end
+
+  namespace :import do
+    desc <<-DESC
+      Performs a dry run of importing all employees from Slack into the Dolores Landingham bot.
+      This task is meant to be run by a user on the command line.
+    DESC
+    task dry_run: :environment do
+      start_time = Time.now
+
+      puts "Employee import dry run task started at #{start_time}."
+
+      import_statistics = EmployeeImporter.new.import(dry_run: true)
+
+      end_time = Time.now
+      duration = (start_time - end_time) / 1.seconds
+
+      puts "Employee import dry run task finished at #{end_time} (#{duration} seconds running time)."
+      puts "Employees imported: #{import_statistics[:created]} (dry run)".green
+      puts "Employees skipped: #{import_statistics[:skipped]} (dry run)".yellow
+    end
+  end
+end

--- a/spec/services/employee_importer_spec.rb
+++ b/spec/services/employee_importer_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe EmployeeImporter do
+  describe "#import" do
+    it "returns a hash with the number of created employees when no employees exist yet" do
+      expected_import_results = {
+        created: 3,
+        skipped: 0,
+        dry_run: false
+      }
+
+      actual_import_results = EmployeeImporter.new.import
+
+      expect(actual_import_results).to include(expected_import_results)
+    end
+
+    it "returns a hash with the number of skipped employees when employees already exist" do
+      expected_import_results = {
+        created: 0,
+        skipped: 3,
+        dry_run: false
+      }
+
+      actual_import_results = EmployeeImporter.new.import
+      actual_import_results = EmployeeImporter.new.import
+
+      expect(actual_import_results).to include(expected_import_results)
+    end
+
+    it "returns a hash with the dry_run flag set to true when a dry run import is performed" do
+      expected_import_results = {
+        created: 3,
+        skipped: 0,
+        dry_run: true
+      }
+
+      actual_import_results = EmployeeImporter.new.import(dry_run: true)
+
+      expect(actual_import_results).to include(expected_import_results)
+    end
+  end
+end

--- a/spec/services/slack_user_importer_spec.rb
+++ b/spec/services/slack_user_importer_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe SlackUserImporter do
+  describe "#slack_usernames" do
+    it "returns an array of all Slack usernames" do
+      expected_slack_usernames = [
+        "testusername",
+        "testusername2",
+        "testusername3",
+      ]
+
+      slack_usernames = SlackUserImporter.new("", Slack::Web::Client.new).slack_usernames
+
+      expect(slack_usernames).to match_array(expected_slack_usernames)
+    end
+  end
+end


### PR DESCRIPTION
This changeset adds an importer to retrieve all Slack users within the organization.  It is configured as a Rake task and includes support for performing a dry run of the import.

You can run the import task with the following command:

```
rake employees:import
```

You can also perform a dry run of the import to see if there will be any errors:

```
rake employees:import:dry_run
```

I brought this branch up-to-date with the most recent activity on the `master` branch and made sure all of the tests passed, but it has been several months since I last worked on this and I am unsure if it still meets the needs of #72.  It does pull in all available Slack usernames in the organization and defaults the start date to whenever the import was run.

In the future, it'd be nice to leverage the Team API for this information instead as it should also contain the employee start dates.  I have added several `TODO` notes in the code around this.

If someone is able to take a look at this and carry the work over the finish line (the branch - `cc-72-import-employees` - is pushed remotely so you can get to the code easily), I'd greatly appreciate it!  Please feel free to reach out to me with any questions/concerns/feedback regarding what I've done so far.

/cc @jessieay and @gemfarmer