### PR TITLE
Updating the setup script to create the tmp/pids dir

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -31,6 +31,10 @@ if ! command -v foreman > /dev/null; then
   printf 'See https://github.com/ddollar/foreman for install instructions.\n'
 fi
 
+# Foreman uses the tmp/pids directory to create its processes, so we need to
+# make sure that dir is created
+mkdir -p tmp/pids
+
 # Only if this isn't CI
 # if [ -z "$CI" ]; then
 # fi


### PR DESCRIPTION
Foreman tries to use the tmp/pids directory when it starts and will error
out at times if it's not there.

This just adds a small mkdir to the setup script to ensure that the directory
is created as part of the setup