### PR TITLE
Use slack user ids

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -35,6 +35,7 @@ class EmployeesController < ApplicationController
     @employee = Employee.find(params[:id])
     @employee.slack_username = params[:employee][:slack_username]
     @employee.validate_slack_username_in_org
+    @employee.add_slack_user_id_to_employee
 
 
     if @employee.errors.full_messages.empty? && @employee.update(employee_params)

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -7,6 +7,8 @@ class EmployeesController < ApplicationController
   def create
     @employee = Employee.new(employee_params)
     @employee.validate_slack_username_in_org
+    @employee.add_slack_user_id_to_employee
+
 
     if @employee.errors.full_messages.empty? && @employee.save
       flash[:notice] = "Thanks for adding #{@employee.slack_username}"

--- a/app/controllers/test_messages_controller.rb
+++ b/app/controllers/test_messages_controller.rb
@@ -7,9 +7,12 @@ class TestMessagesController < ApplicationController
     message = ScheduledMessage.find(params[:scheduled_message_id])
     employee = Employee.find_by(slack_username: slack_username)
 
-    if employee
+    if !employee.slack_channel_id.nil? || !employee.slack_user_id.nil?
       MessageSender.new(employee, message).delay.run
       flash[:notice] = "Test message sent successfully"
+      redirect_to scheduled_messages_path
+    elsif employee.slack_channel_id.nil? || employee.slack_user_id.nil?
+      flash[:error] = "Oops! Looks like this employees information isn't up to date. Check to make sure they haven't changed their slackname!"
       redirect_to scheduled_messages_path
     else
       flash[:error] = "Oops! Looks like that employee isn't in the Dolores system yet! Make sure you've entered the Slack handle (#{slack_username}) for the employee before sending him/her/them a test message."

--- a/app/controllers/test_messages_controller.rb
+++ b/app/controllers/test_messages_controller.rb
@@ -22,4 +22,9 @@ class TestMessagesController < ApplicationController
   def slack_username
     params[:test_message][:slack_username]
   end
+
+  def slack_user_id
+    params[:test_message][:slack_user_id]
+  end
+
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -29,7 +29,7 @@ class Employee < ActiveRecord::Base
 
   def add_slack_user_id_to_employee
     user_id = EmployeeFinder.new(slack_username).slack_user_id
-    if !user_id.nil?
+    if user_id.present?
       self.slack_user_id = user_id
     end
   end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -28,8 +28,9 @@ class Employee < ActiveRecord::Base
   end
 
   def add_slack_user_id_to_employee
-    if !EmployeeFinder.new(slack_username).slack_user_id.nil?
-      self.slack_user_id = EmployeeFinder.new(slack_username).slack_user_id
+    user_id = EmployeeFinder.new(slack_username).slack_user_id
+    if !user_id.nil?
+      self.slack_user_id = user_id
     end
   end
 end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -26,4 +26,10 @@ class Employee < ActiveRecord::Base
       )
     end
   end
+
+  def add_slack_user_id_to_employee
+    if !EmployeeFinder.new(slack_username).slack_user_id.nil?
+      self.slack_user_id = EmployeeFinder.new(slack_username).slack_user_id
+    end
+  end
 end

--- a/app/services/employee_finder.rb
+++ b/app/services/employee_finder.rb
@@ -10,6 +10,10 @@ class EmployeeFinder
     SlackUserFinder.new(@slack_username, client).existing_user?
   end
 
+  def slack_user_id
+    SlackUserFinder.new(@slack_username, client).user_id
+  end
+
   def users_list
     SlackUserFinder.new(@slack_username, client).users_list
   end

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -9,8 +9,9 @@ class MessageSender
   def run
     configure_slack
 
-    if employee.slack_user_id.nil? && !EmployeeFinder.new(employee.slack_username).slack_user_id.nil?
-      user_id = EmployeeFinder.new(employee.slack_username).slack_user_id
+    user_id = EmployeeFinder.new(employee.slack_username).slack_user_id
+
+    if employee.slack_user_id.nil? && !user_id.nil?
       employee.slack_user_id = user_id
       employee.save
     end

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -8,9 +8,15 @@ class MessageSender
 
   def run
     configure_slack
+    
+    if employee.slack_user_id.nil? && !EmployeeFinder.new(employee.slack_username).slack_user_id.nil?
+      user_id = EmployeeFinder.new(employee.slack_username).slack_user_id
+      employee.slack_user_id = user_id
+      employee.save
+    end
 
     if employee.slack_channel_id.nil?
-      channel_id = SlackChannelIdFinder.new(employee.slack_username, client).run
+      channel_id = SlackChannelIdFinder.new(employee.slack_user_id, client).run
       employee.slack_channel_id = channel_id
       employee.save
     end

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -8,7 +8,7 @@ class MessageSender
 
   def run
     configure_slack
-    
+
     if employee.slack_user_id.nil? && !EmployeeFinder.new(employee.slack_username).slack_user_id.nil?
       user_id = EmployeeFinder.new(employee.slack_username).slack_user_id
       employee.slack_user_id = user_id
@@ -21,7 +21,7 @@ class MessageSender
       employee.save
     end
 
-    if employee.slack_channel_id
+    if !employee.slack_channel_id.nil?
       begin
         post_message(channel_id: employee.slack_channel_id, message: message)
         create_sent_scheduled_message(
@@ -36,7 +36,14 @@ class MessageSender
           error: error,
         )
       end
+    else
+      create_sent_scheduled_message(
+        employee: employee,
+        scheduled_message: message,
+        error: StandardError.new("Was unable to find a slack channel for this username"),
+      )
     end
+
   end
 
   private

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -9,10 +9,10 @@ class MessageSender
   def run
     configure_slack
 
-    user_id = EmployeeFinder.new(employee.slack_username).slack_user_id
+    slack_user_id = EmployeeFinder.new(employee.slack_username).slack_user_id
 
-    if employee.slack_user_id.nil? && !user_id.nil?
-      employee.slack_user_id = user_id
+    if employee.slack_user_id.nil? && slack_user_id.present?
+      employee.slack_user_id = slack_user_id
       employee.save
     end
 
@@ -22,7 +22,7 @@ class MessageSender
       employee.save
     end
 
-    if !employee.slack_channel_id.nil?
+    if employee.slack_channel_id.present?
       begin
         post_message(channel_id: employee.slack_channel_id, message: message)
         create_sent_scheduled_message(
@@ -41,7 +41,7 @@ class MessageSender
       create_sent_scheduled_message(
         employee: employee,
         scheduled_message: message,
-        error: StandardError.new("Was unable to find a slack channel for this username"),
+        error: StandardError.new("Was unable to find a slack channel for user with name #{employee.slack_username} and slack user id #{employee.slack_user_id}"),
       )
     end
 

--- a/app/services/slack_api_wrapper.rb
+++ b/app/services/slack_api_wrapper.rb
@@ -14,6 +14,12 @@ class SlackApiWrapper
     end
   end
 
+  def slack_user_by_id
+    @slack_user ||= all_slack_users.find do |user_data|
+      user_data["id"] == slack_username
+    end
+  end
+
   def all_slack_users
     client.users_list["members"]
   end

--- a/app/services/slack_channel_id_finder.rb
+++ b/app/services/slack_channel_id_finder.rb
@@ -1,6 +1,6 @@
 class SlackChannelIdFinder < SlackApiWrapper
   def run
-    if slack_user
+    if slack_user_by_id
       slack_user_id = slack_user["id"]
       chat = client.im_open(user: slack_user_id)
       chat["channel"]["id"]

--- a/app/services/slack_user_finder.rb
+++ b/app/services/slack_user_finder.rb
@@ -4,7 +4,7 @@ class SlackUserFinder < SlackApiWrapper
   end
 
   def user_id
-    if !slack_user.nil?
+    if slack_user.present?
       slack_user["id"]
     end
   end

--- a/app/services/slack_user_finder.rb
+++ b/app/services/slack_user_finder.rb
@@ -3,6 +3,12 @@ class SlackUserFinder < SlackApiWrapper
     !slack_user.nil?
   end
 
+  def user_id
+    if !slack_user.nil?
+      slack_user["id"]
+    end
+  end
+
   def users_list
     all_slack_users
   end

--- a/db/migrate/20160430175239_add_slack_user_id_to_employee.rb
+++ b/db/migrate/20160430175239_add_slack_user_id_to_employee.rb
@@ -1,5 +1,6 @@
 class AddSlackUserIdToEmployee < ActiveRecord::Migration
   def change
     add_column :employees, :slack_user_id, :string
+    add_index :employees, :slack_user_id
   end
 end

--- a/db/migrate/20160430175239_add_slack_user_id_to_employee.rb
+++ b/db/migrate/20160430175239_add_slack_user_id_to_employee.rb
@@ -1,0 +1,5 @@
+class AddSlackUserIdToEmployee < ActiveRecord::Migration
+  def change
+    add_column :employees, :slack_user_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160402214945) do
+ActiveRecord::Schema.define(version: 20160430175239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 20160402214945) do
     t.string   "time_zone",        default: "Eastern Time (US & Canada)", null: false
     t.datetime "deleted_at"
     t.string   "slack_channel_id"
+    t.string   "slack_user_id"
   end
 
   add_index "employees", ["deleted_at"], name: "index_employees_on_deleted_at", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20160430175239) do
   end
 
   add_index "employees", ["deleted_at"], name: "index_employees_on_deleted_at", using: :btree
+  add_index "employees", ["slack_user_id"], name: "index_employees_on_slack_user_id", using: :btree
 
   create_table "scheduled_messages", force: :cascade do |t|
     t.datetime "created_at",                                       null: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   sequence(:slack_username) { |n| "testusername#{n}" }
+  sequence(:slack_user_id) { |n| "ID123#{n}" }
+
 
   factory :user do
     email "test@example.com"
@@ -12,6 +14,7 @@ FactoryGirl.define do
 
   factory :employee do
     slack_username
+    slack_user_id
     started_on  { Date.today }
     time_zone "Eastern Time (US & Canada)"
   end

--- a/spec/services/message_employee_matcher_spec.rb
+++ b/spec/services/message_employee_matcher_spec.rb
@@ -82,7 +82,7 @@ describe MessageEmployeeMatcher do
 
         allow(Slack::Web::Client).to receive(:new).and_return(client_double)
         allow(SlackChannelIdFinder).
-          to receive(:new).with(employee_one.slack_username, client_double).
+          to receive(:new).with(employee_one.slack_user_id, client_double).
           and_return(slack_channel_finder_double)
 
         pre_matched_employees_and_messages = MessageEmployeeMatcher.new(scheduled_message).run

--- a/spec/services/message_sender_spec.rb
+++ b/spec/services/message_sender_spec.rb
@@ -99,7 +99,7 @@ describe MessageSender do
 
     expect(SentScheduledMessage).to have_received(:create).with(
       employee: employee,
-      error_message: "Was unable to find a slack channel for this username",
+      error_message: "Was unable to find a slack channel for user with name #{employee.slack_username} and slack user id #{employee.slack_user_id}",
       scheduled_message: scheduled_message,
       sent_on: Date.today,
       sent_at: Time.parse("10:00:00 UTC"),

--- a/spec/services/message_sender_spec.rb
+++ b/spec/services/message_sender_spec.rb
@@ -81,7 +81,7 @@ describe MessageSender do
     Timecop.return
   end
 
-  it "does not error if channel not found for slack user" do
+  it "does error if channel not found for slack user" do
     Timecop.freeze(Time.parse("10:00:00 UTC"))
 
     scheduled_message = create(:scheduled_message)
@@ -97,7 +97,14 @@ describe MessageSender do
 
     MessageSender.new(employee, scheduled_message).run
 
-    expect(SentScheduledMessage).not_to have_received(:create)
+    expect(SentScheduledMessage).to have_received(:create).with(
+      employee: employee,
+      error_message: "Was unable to find a slack channel for this username",
+      scheduled_message: scheduled_message,
+      sent_on: Date.today,
+      sent_at: Time.parse("10:00:00 UTC"),
+      message_body: scheduled_message.body,
+    )
 
     Timecop.return
   end

--- a/spec/services/message_sender_spec.rb
+++ b/spec/services/message_sender_spec.rb
@@ -12,7 +12,7 @@ describe MessageSender do
 
     allow(Slack::Web::Client).to receive(:new).and_return(client_double)
     allow(SlackChannelIdFinder).
-      to receive(:new).with(employee.slack_username, client_double).
+      to receive(:new).with(employee.slack_user_id, client_double).
       and_return(slack_channel_finder_double)
     allow(SentScheduledMessage).to receive(:create)
 
@@ -41,7 +41,7 @@ describe MessageSender do
 
     allow(Slack::Web::Client).to receive(:new).and_return(client_double)
     allow(SlackChannelIdFinder).
-      to receive(:new).with(employee.slack_username, client_double).
+      to receive(:new).with(employee.slack_user_id, client_double).
       and_return(slack_channel_finder_double)
     allow(SentScheduledMessage).to receive(:create)
 
@@ -63,7 +63,7 @@ describe MessageSender do
 
     allow(Slack::Web::Client).to receive(:new).and_return(client_double)
     allow(SlackChannelIdFinder).
-      to receive(:new).with(employee.slack_username, client_double).
+      to receive(:new).with(employee.slack_user_id, client_double).
       and_return(slack_channel_finder_double)
     allow(SentScheduledMessage).to receive(:create)
 
@@ -91,7 +91,7 @@ describe MessageSender do
 
     allow(Slack::Web::Client).to receive(:new).and_return(client_double)
     allow(SlackChannelIdFinder).
-      to receive(:new).with(employee.slack_username, client_double).
+      to receive(:new).with(employee.slack_user_id, client_double).
       and_return(slack_channel_id_double)
     allow(SentScheduledMessage).to receive(:create)
 
@@ -112,7 +112,7 @@ describe MessageSender do
 
     allow(Slack::Web::Client).to receive(:new).and_return(client_double)
     allow(SlackChannelIdFinder).
-      to receive(:new).with(employee.slack_username, client_double).
+      to receive(:new).with(employee.slack_user_id, client_double).
       and_return(slack_channel_id_double)
     allow(SentScheduledMessage).to receive(:create)
 

--- a/spec/services/slack_channel_id_finder_spec.rb
+++ b/spec/services/slack_channel_id_finder_spec.rb
@@ -4,10 +4,10 @@ describe SlackChannelIdFinder do
   describe "#run" do
     it "finds the slack user channel id if member of bot's org" do
       channel_id_from_fixture = "123ABC_IM_ID"
-      slack_username_from_fixture = "testusername"
+      slack_user_id_from_fixture = "123ABC_ID"
 
       channel_id = SlackChannelIdFinder.new(
-        slack_username_from_fixture,
+        slack_user_id_from_fixture,
         Slack::Web::Client.new
       ).run
 


### PR DESCRIPTION
Fixes issue(s) #157 

Changes proposed in this pull request:

- Save slack user id when the employee is created
- Check for missing slack user ids when sending a message, and add them if it can
- Look up the channel id (used to post messages) by slack user id instead of slack username
- Log sent message errors if slack channel for a username can't be found (indicating a bad username) at some point along the way
- DB migration and test updates

@jessieay @nicoleslaw 