### PR TITLE
Validate uniqueness of Employee slack username with scope

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -3,10 +3,16 @@ class Employee < ActiveRecord::Base
 
   has_many :sent_scheduled_messages, dependent: :destroy
 
-  validates :slack_username,
-    presence: true,
-    uniqueness: true,
-    format: { with: /\A[a-z_0-9.]+\z/, message: "Slack usernames can only contain lowercase letters, numbers, underscores, and periods." }
+  validates :slack_username, presence: true
+  validates_uniqueness_of :slack_username, conditions: -> { where(deleted_at: nil) }
+  validates(
+    :slack_username,
+    format: {
+      with: /\A[a-z_0-9.]+\z/,
+      message: "Slack usernames can only contain lowercase letters, numbers, underscores, and periods."
+    }
+  )
+
   validates :started_on, presence: true
   validates :time_zone, presence: true
 

--- a/app/views/test_messages/new.html.erb
+++ b/app/views/test_messages/new.html.erb
@@ -1,7 +1,7 @@
 <%= render 'header', :title => 'Send test message' %>
 
 <section class="main-content">
-	<%= render "flashes" -%>
+  <%= render "flashes" -%>
   <%= simple_form_for :test_message, url: scheduled_message_test_messages_path(@message) do |form| %>
     <%= form.input :body, input_html: { value: @message.body }, readonly: true, label: "Message body to send (to edit, update the scheduled message you are testing)" %>
     <%= form.input :slack_username, label: "Slack username to send test to", as: :string %>

--- a/spec/features/delete_employees_spec.rb
+++ b/spec/features/delete_employees_spec.rb
@@ -12,4 +12,23 @@ feature "Delete employees" do
 
     expect(page).to have_content("You deleted #{employee.slack_username}")
   end
+
+  scenario "and re-add" do
+    username = "testusername2"
+    _employee = create(:employee, slack_username: username)
+
+    login_with_oauth
+    visit employees_path
+    page.find(".button-delete").click
+
+    visit new_employee_path
+    fill_in "Slack username", with: username
+    select "2015", from: "employee_started_on_1i"
+    select "June", from: "employee_started_on_2i"
+    select "1", from: "employee_started_on_3i"
+    select "Eastern Time (US & Canada)", from: "employee_time_zone"
+    click_on "Create Employee"
+
+    expect(page).to have_content("Thanks for adding #{username}")
+  end
 end


### PR DESCRIPTION
Fixes issue: was not able to delete an employee and re-add
* We are using paranoia to soft delete
* Need to scope uniqueness validations to records that are not deleted