### PR TITLE
Allow More Valid Slack Usernames

### DIFF
--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -8,8 +8,8 @@ class Employee < ActiveRecord::Base
   validates(
     :slack_username,
     format: {
-      with: /\A[a-z_0-9.]+\z/,
-      message: "Slack usernames can only contain lowercase letters, numbers, underscores, and periods."
+      with: /\A[a-z_0-9.-]+\z/,
+      message: "Slack usernames can only contain lowercase letters, numbers, underscores, hyphens, and periods."
     }
   )
 

--- a/app/views/employees/_form.html.erb
+++ b/app/views/employees/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for @employee do |form| %>
   <%= form.input :slack_username,
     required: true,
-    pattern: '^[^@]\w+[^ ]$',
+    pattern: '^[a-z0-9_.-]{1,21}$',
     input_html: { title: I18n.t('employees.errors.slack_username') } %>
   <%= form.input :started_on,
     input_html: { class: "date-time-select" },

--- a/spec/features/create_employees_spec.rb
+++ b/spec/features/create_employees_spec.rb
@@ -16,6 +16,21 @@ feature "Create employees" do
     expect(page).to have_content("Thanks for adding #{username}")
   end
 
+  scenario "with short username" do
+    username = "u2"
+    login_with_oauth
+
+    visit new_employee_path
+    fill_in "Slack username", with: username
+    select "2015", from: "employee_started_on_1i"
+    select "June", from: "employee_started_on_2i"
+    select "1", from: "employee_started_on_3i"
+    select "Eastern Time (US & Canada)", from: "employee_time_zone"
+    click_on "Create Employee"
+
+    expect(page).to have_content("Thanks for adding #{username}")
+  end
+
   scenario "unsuccessfully with invalid username" do
     username = "fakeusername2"
     login_with_oauth

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -10,6 +10,9 @@ describe Employee do
      it { should validate_presence_of(:slack_username) }
      it { should validate_uniqueness_of(:slack_username) }
      it { should allow_value("test_user_1").for(:slack_username) }
+     it { should allow_value("x").for(:slack_username) }
+     it { should allow_value("test-user-1").for(:slack_username) }
+     it { should allow_value("test.user.1").for(:slack_username) }
      it { should_not allow_value("TEST USER 1").for(:slack_username) }
      it { should_not allow_value("@test_user_1").for(:slack_username) }
      it { should validate_presence_of(:started_on) }

--- a/spec/support/fixtures/users_list.json
+++ b/spec/support/fixtures/users_list.json
@@ -48,6 +48,22 @@
         "is_owner": true,
         "has_2fa": false,
         "has_files": true
+      },
+      {
+        "id": "987FED_ID",
+        "name": "u2",
+        "deleted": false,
+        "color": "9f69e7",
+        "profile": {
+          "first_name": "Lily",
+          "last_name": "Jones",
+          "real_name": "Lily Jones",
+          "email": "lily@slack.com"
+        },
+        "is_admin": true,
+        "is_owner": true,
+        "has_2fa": false,
+        "has_files": true
       }
     ]
 }

--- a/spec/support/fixtures/users_list.json
+++ b/spec/support/fixtures/users_list.json
@@ -10,7 +10,7 @@
           "first_name": "Bobby",
           "last_name": "Tables",
           "real_name": "Bobby Tables",
-          "email": "bobby@slack.com"
+          "email": "bobby@example.com"
         },
         "is_admin": true,
         "is_owner": true,
@@ -26,7 +26,7 @@
           "first_name": "Joe",
           "last_name": "Smith",
           "real_name": "Joe Smith",
-          "email": "joe@slack.com"
+          "email": "joe@example.com"
         },
         "is_admin": true,
         "is_owner": true,
@@ -42,7 +42,7 @@
           "first_name": "Jane",
           "last_name": "Smith",
           "real_name": "Jane Smith",
-          "email": "jane@slack.com"
+          "email": "jane@example.com"
         },
         "is_admin": true,
         "is_owner": true,
@@ -58,7 +58,7 @@
           "first_name": "Lily",
           "last_name": "Jones",
           "real_name": "Lily Jones",
-          "email": "lily@slack.com"
+          "email": "lily@example.com"
         },
         "is_admin": true,
         "is_owner": true,


### PR DESCRIPTION
Fixes issue(s) #175

Changes proposed in this pull request:

- Allow Slack usernames with fewer than three characters
- Allow Slack usernames with hyphens