### PR TITLE
Adds dev configuration in vagrant.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,33 @@ locally and pushing `master` or by using the merge button on GitHub.
 Each message created will send a specified number of **business days** after an employee joins 18F.
 What constitutes a business day is managed by the gem `business_time` and is configured [here](config/initializers/business_time.rb) and [here](config/business_time.yml). To add days that dolores will skip, add that date to the `holidays` field in [this yaml config file](config/business_time.yml).
 
+### Vagrant setup
+
+A [Vagrant](http://vagrantup.com) configuration is available that creates a
+local server preconfigured with all the dependencies required by this project.
+
+To use vagrant for development:
+
+```
+# Provision a new virtual server in VirtualBox (installs postgres, other
+# dependencies, and sets up the project's database)
+vagrant up
+
+# connect to the server to run foreman, run tests, etc:
+vagrant ssh
+
+# Vagrant shares your project's directory with the virtual server in the
+# /vagrant directory:
+cd /vagrant
+
+# run tests
+rake
+
+# Vagrant maps port 5000 of the virtual server to localhost:5000, so it seems
+# like you are running the project locally:
+foreman start
+```
+
 ### App setup
 
 Before running bin/setup, ensure that 'foreman' is removed from the Gemfile.  

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "1024"
+  end
+
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    # print command to stdout before executing it:
+    set -x
+
+    curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+    curl -L https://get.rvm.io | bash -s stable --autolibs=enabled --ruby
+
+    source "$HOME/.rvm/scripts/rvm"
+    rvm install 2.3.1
+    rvm use 2.3.1
+
+    echo 'source "$HOME/.rvm/scripts/rvm"' >> .bashrc
+    echo "rvm use 2.3.1" >> .bashrc
+
+    # install postgres
+    sudo apt-get -y install postgresql postgresql-contrib libpq-dev node npm
+    sudo -u postgres psql -c "CREATE USER vagrant WITH PASSWORD 'vagrant';"
+    sudo -u postgres psql -c "ALTER USER vagrant CREATEDB;"
+
+    echo "localhost:5432:*:vagrant:vagrant" > .pgpass
+    chmod 0600 .pgpass
+
+    sudo mv /usr/sbin/node /usr/sbin/node-bak
+    sudo ln -s /usr/bin/nodejs /usr/bin/node
+    sudo npm install -g phantomjs
+
+    cd /vagrant
+
+    gem install bundle
+    cp .sameple.env .env
+
+    ./bin/setup
+  SHELL
+end


### PR DESCRIPTION
This PR adds a vagrant configuration that installs all dependencies required to get a dev instance up and running. One can:

 1. clone the repository
 2. run `vagrant up` to bring up a new linux server on their local dev box.
 3. login via `vagrant ssh` to run tests, foreman, etc (eg `cd /vagrant; foreman start`)