### PR TITLE
[Connects #72] Add nightly tasks to import new employees and update usernames

### DIFF
--- a/app/services/employee_finder.rb
+++ b/app/services/employee_finder.rb
@@ -3,7 +3,6 @@ require "slack-ruby-client"
 class EmployeeFinder
   def initialize(slack_username = '')
     @slack_username = slack_username
-    configure_slack
   end
 
   def existing_employee?
@@ -19,12 +18,6 @@ class EmployeeFinder
   end
 
   private
-
-  def configure_slack
-    Slack.configure do |config|
-      config.token = ENV['SLACK_API_TOKEN']
-    end
-  end
 
   def client
     @client ||= Slack::Web::Client.new

--- a/app/services/employee_importer.rb
+++ b/app/services/employee_importer.rb
@@ -1,0 +1,61 @@
+require "slack-ruby-client"
+
+class EmployeeImporter
+  def initialize
+    configure_slack
+  end
+
+  def import(dry_run = false)
+    import_results = {created: 0, skipped: 0, dry_run: false}
+    slack_user_importer = SlackUserImporter.new("", client)
+    total_employees = slack_user_importer.slack_usernames.count
+
+    slack_user_importer.slack_usernames.each_with_index do |slack_username, index|
+      if !dry_run
+        success = import_employee(slack_username)
+      else
+        success = dry_import_employee(slack_username)
+        import_results[:dry_run] = true
+      end
+
+      if success
+        Rails.logger.info "#{index + 1}/#{total_employees}: Created #{slack_username}#{" (dry run)" if dry_run}".green
+        import_results[:created] += 1
+      else
+        Rails.logger.info "#{index + 1}/#{total_employees}: Skipped #{slack_username}#{" (dry run)" if dry_run}".yellow
+        import_results[:skipped] += 1
+      end
+    end
+
+    import_results
+  end
+
+  private
+
+  def client
+    @client ||= Slack::Web::Client.new
+  end
+
+  def configure_slack
+    Slack.configure do |config|
+      config.token = ENV['SLACK_API_TOKEN']
+    end
+  end
+
+  def dry_import_employee(slack_username)
+    Employee.where(slack_username: slack_username).size == 0
+  end
+
+  def import_employee(slack_username)
+    # TODO:  Once we can hook up the Team API, we'll want to grab the start
+    # TODO:  date of an employee from there instead of defaulting to the
+    # TODO:  current date and time.
+
+    # TODO:  We'll also want to verify that the Slack user is an actual person
+    # TODO:  Against the Team API - Slack alone cannot tell us if they are real
+    # TODO:  or not.
+
+    employee = Employee.new(slack_username: slack_username, started_on: Time.now)
+    employee.save
+  end
+end

--- a/app/services/employee_updater.rb
+++ b/app/services/employee_updater.rb
@@ -1,0 +1,7 @@
+class EmployeeUpdater
+  def run
+    Employee.find_each do |employee|
+      SlackUsernameUpdater.new(employee).update
+    end
+  end
+end

--- a/app/services/message_sender.rb
+++ b/app/services/message_sender.rb
@@ -7,8 +7,6 @@ class MessageSender
   end
 
   def run
-    configure_slack
-
     slack_user_id = EmployeeFinder.new(employee.slack_username).slack_user_id
 
     if employee.slack_user_id.nil? && slack_user_id.present?
@@ -50,12 +48,6 @@ class MessageSender
   private
 
   attr_reader :employee, :message
-
-  def configure_slack
-    Slack.configure do |config|
-      config.token = ENV['SLACK_API_TOKEN']
-    end
-  end
 
   def client
     @client ||= Slack::Web::Client.new

--- a/app/services/slack_user_finder.rb
+++ b/app/services/slack_user_finder.rb
@@ -9,6 +9,12 @@ class SlackUserFinder < SlackApiWrapper
     end
   end
 
+  def username
+    if slack_user_by_id.present?
+      slack_user["name"]
+    end
+  end
+
   def users_list
     all_slack_users
   end

--- a/app/services/slack_user_importer.rb
+++ b/app/services/slack_user_importer.rb
@@ -1,0 +1,5 @@
+class SlackUserImporter < SlackApiWrapper
+  def slack_usernames
+    all_slack_users.map { |slack_user| slack_user["name"] }
+  end
+end

--- a/app/services/slack_username_updater.rb
+++ b/app/services/slack_username_updater.rb
@@ -1,0 +1,24 @@
+class SlackUsernameUpdater < SlackApiWrapper
+  def initialize(employee)
+    @employee = employee
+  end
+
+  def update
+    slack_username = SlackUserFinder.new(
+      employee.slack_user_id,
+      client,
+    ).username
+
+    if employee.slack_username != slack_username
+      employee.update(slack_username: slack_username)
+    end
+  end
+
+  private
+
+  attr_reader :employee
+
+  def client
+    @client ||= Slack::Web::Client.new
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -7,4 +7,14 @@ module Clockwork
     puts "Sending scheduled messages"
     DailyMessageSender.new.delay.run
   end
+
+  every(1.day, "employees.import", at: "03:00", tz: "UTC") do
+    puts "Importing new employees"
+    EmployeeImporter.new.delay.run
+  end
+
+  every(1.day, "employees.update", at: "03:00", tz: "UTC") do
+    puts "Updating employee slack usernames"
+    EmployeeUpdater.new.delay.run
+  end
 end

--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -1,0 +1,3 @@
+Slack.configure do |config|
+  config.token = ENV["SLACK_API_TOKEN"]
+end

--- a/lib/tasks/employees.rake
+++ b/lib/tasks/employees.rake
@@ -1,0 +1,41 @@
+namespace :employees do
+  desc "Imports all employees from Slack into the Dolores Landingham bot."
+  task import: :environment do
+    logger = ActiveSupport::Logger.new('log/employees_import.log')
+    start_time = Time.now
+
+    logger.info "Employee import task started at #{start_time}."
+
+    import_statistics = EmployeeImporter.new.import
+
+    end_time = Time.now
+    duration = (start_time - end_time) / 1.seconds
+
+    logger.info "Employee import task finished at #{end_time} (#{duration} seconds running time)."
+    logger.info "Employees imported: #{import_statistics[:created]}"
+    logger.info "Employees skipped: #{import_statistics[:skipped]}"
+
+    logger.close
+  end
+
+  namespace :import do
+    desc <<-DESC
+      Performs a dry run of importing all employees from Slack into the Dolores Landingham bot.
+      This task is meant to be run by a user on the command line.
+    DESC
+    task dry_run: :environment do
+      start_time = Time.now
+
+      puts "Employee import dry run task started at #{start_time}."
+
+      import_statistics = EmployeeImporter.new.import(dry_run: true)
+
+      end_time = Time.now
+      duration = (start_time - end_time) / 1.seconds
+
+      puts "Employee import dry run task finished at #{end_time} (#{duration} seconds running time)."
+      puts "Employees imported: #{import_statistics[:created]} (dry run)".green
+      puts "Employees skipped: #{import_statistics[:skipped]} (dry run)".yellow
+    end
+  end
+end

--- a/lib/tasks/employees.rake
+++ b/lib/tasks/employees.rake
@@ -1,7 +1,7 @@
 namespace :employees do
   desc "Imports all employees from Slack into the Dolores Landingham bot."
   task import: :environment do
-    logger = ActiveSupport::Logger.new('log/employees_import.log')
+    logger = ActiveSupport::Logger.new("log/employees_import.log")
     start_time = Time.now
 
     logger.info "Employee import task started at #{start_time}."

--- a/spec/services/employee_importer_spec.rb
+++ b/spec/services/employee_importer_spec.rb
@@ -4,12 +4,12 @@ describe EmployeeImporter do
   describe "#import" do
     it "returns a hash with the number of created employees when no employees exist yet" do
       expected_import_results = {
-        created: 3,
+        created: 4,
         skipped: 0,
         dry_run: false
       }
 
-      actual_import_results = EmployeeImporter.new.import
+      actual_import_results = EmployeeImporter.new.run
 
       expect(actual_import_results).to include(expected_import_results)
     end
@@ -17,24 +17,24 @@ describe EmployeeImporter do
     it "returns a hash with the number of skipped employees when employees already exist" do
       expected_import_results = {
         created: 0,
-        skipped: 3,
+        skipped: 4,
         dry_run: false
       }
 
-      actual_import_results = EmployeeImporter.new.import
-      actual_import_results = EmployeeImporter.new.import
+      EmployeeImporter.new.run
+      actual_import_results = EmployeeImporter.new.run
 
       expect(actual_import_results).to include(expected_import_results)
     end
 
     it "returns a hash with the dry_run flag set to true when a dry run import is performed" do
       expected_import_results = {
-        created: 3,
+        created: 4,
         skipped: 0,
         dry_run: true
       }
 
-      actual_import_results = EmployeeImporter.new.import(dry_run: true)
+      actual_import_results = EmployeeImporter.new.run(dry_run: true)
 
       expect(actual_import_results).to include(expected_import_results)
     end

--- a/spec/services/employee_importer_spec.rb
+++ b/spec/services/employee_importer_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe EmployeeImporter do
+  describe "#import" do
+    it "returns a hash with the number of created employees when no employees exist yet" do
+      expected_import_results = {
+        created: 3,
+        skipped: 0,
+        dry_run: false
+      }
+
+      actual_import_results = EmployeeImporter.new.import
+
+      expect(actual_import_results).to include(expected_import_results)
+    end
+
+    it "returns a hash with the number of skipped employees when employees already exist" do
+      expected_import_results = {
+        created: 0,
+        skipped: 3,
+        dry_run: false
+      }
+
+      actual_import_results = EmployeeImporter.new.import
+      actual_import_results = EmployeeImporter.new.import
+
+      expect(actual_import_results).to include(expected_import_results)
+    end
+
+    it "returns a hash with the dry_run flag set to true when a dry run import is performed" do
+      expected_import_results = {
+        created: 3,
+        skipped: 0,
+        dry_run: true
+      }
+
+      actual_import_results = EmployeeImporter.new.import(dry_run: true)
+
+      expect(actual_import_results).to include(expected_import_results)
+    end
+  end
+end

--- a/spec/services/slack_user_importer_spec.rb
+++ b/spec/services/slack_user_importer_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe SlackUserImporter do
+  describe "#slack_usernames" do
+    it "returns an array of all Slack usernames" do
+      expected_slack_usernames = [
+        "testusername",
+        "testusername2",
+        "testusername3",
+      ]
+
+      slack_usernames = SlackUserImporter.new("", Slack::Web::Client.new).slack_usernames
+
+      expect(slack_usernames).to match_array(expected_slack_usernames)
+    end
+  end
+end

--- a/spec/services/slack_user_importer_spec.rb
+++ b/spec/services/slack_user_importer_spec.rb
@@ -7,6 +7,7 @@ describe SlackUserImporter do
         "testusername",
         "testusername2",
         "testusername3",
+        "u2",
       ]
 
       slack_usernames = SlackUserImporter.new("", Slack::Web::Client.new).slack_usernames

--- a/spec/services/slack_username_updater_spec.rb
+++ b/spec/services/slack_username_updater_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe SlackUsernameUpdater do
+  describe "#update" do
+    it "updates the employee's username when it has changed" do
+      slack_user_id_from_fixture = "123ABC_ID"
+      employee = create(
+        :employee,
+        slack_username: "oldname",
+        slack_user_id: slack_user_id_from_fixture
+      )
+
+      SlackUsernameUpdater.new(employee).update
+
+      expect(employee.reload.slack_username).to eq "testusername"
+    end
+  end
+end


### PR DESCRIPTION
I started with @ccostino's work in progress (#162), fixed the specs, added a cron task, and made a small change to persist the `slack_user_id` in addition to the username when an employee is imported.

I added a new task to update employee usernames when they are changed. This code is dependent on `slack_user_id` being populated for all employees. I saw that the field is optional in the database; it may be a good idea to run a script to populate the `slack_user_id` field for all employees and then make it `null: false`. Alternatively, I can make a change to run the updater selectively on Employee records that have the `slack_user_id` column populated.