### PR TITLE
Do not check for frozen string literal comment in files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -158,6 +158,9 @@ Style/FormatString:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#sprintf'
   Enabled: false
 
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#instance-vars'


### PR DESCRIPTION
* Necessary for Ruby 3 but annoying right now
* https://github.com/bbatsov/rubocop/pull/2542