### PR TITLE
improve postgres install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,13 @@ Prior to running 'bin/setup', it may be necessary to launch the postgres server 
 
 To get started, run `bin/setup`
 
-if bin/setup fails check your database.yml file and make sure that you have postgres credentials (i.e.,username:<uname>, password:<pw>)
-that will allow you to create a database and tables.
+If bin/setup fails with the following error message:
+
+    fe_sendauth: no password supplied
+    Couldn't create database for {"adapter"=>"postgresql", "database"=>"postgres", "encoding"=>"utf8", "host"=>"localhost", "min_messages"=>"warning", "pool"=>5, "reaping_frequency"=>10, "timeout"=>5000}
+rake aborted!
+
+check your database.yml file.  You might need to set database credentials (i.e.,username:<uname>, password:<pw>)
 
 After setting up, you can run the application using [foreman]:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,8 +81,8 @@ To get started, run `bin/setup`
 
 If bin/setup fails with the following error message:
 
-    fe_sendauth: no password supplied
-    Couldn't create database for {"adapter"=>"postgresql", "database"=>"postgres", "encoding"=>"utf8", "host"=>"localhost", "min_messages"=>"warning", "pool"=>5, "reaping_frequency"=>10, "timeout"=>5000}
+```fe_sendauth: no password supplied```
+```Couldn't create database for {"adapter"=>"postgresql", "database"=>"postgres", "encoding"=>"utf8", "host"=>"localhost", "min_messages"=>"warning", "pool"=>5, "reaping_frequency"=>10, "timeout"=>5000}```
 rake aborted!
 
 check your database.yml file.  You might need to set database credentials (i.e.,username:<uname>, password:<pw>)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,9 +81,11 @@ To get started, run `bin/setup`
 
 If bin/setup fails with the following error message:
 
-```fe_sendauth: no password supplied```
-```Couldn't create database for {"adapter"=>"postgresql", "database"=>"postgres", "encoding"=>"utf8", "host"=>"localhost", "min_messages"=>"warning", "pool"=>5, "reaping_frequency"=>10, "timeout"=>5000}```
+```
+fe_sendauth: no password supplied
+Couldn't create database for {"adapter"=>"postgresql", "database"=>"postgres", "encoding"=>"utf8", "host"=>"localhost", "min_messages"=>"warning", "pool"=>5, "reaping_frequency"=>10, "timeout"=>5000}```
 rake aborted!
+```
 
 check your database.yml file.  You might need to set database credentials (i.e.,username:<uname>, password:<pw>)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,9 @@ Prior to running 'bin/setup', it may be necessary to launch the postgres server 
 
 To get started, run `bin/setup`
 
+if bin/setup fails check your database.yml file and make sure that you have postgres credentials (i.e.,username:<uname>, password:<pw>)
+that will allow you to create a database and tables.
+
 After setting up, you can run the application using [foreman]:
 
     foreman start


### PR DESCRIPTION
- No username or password was included in the database.yml.  There was nothing to let someone know
that these parameters might be needed on their system.