### PR TITLE
add note to contribute.md that specifieds team privcay setting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,8 @@ and then curl with it:
 curl https://api.github.com/user/teams?access_token=YOUR_ACCESS_TOKEN
 ```
 
+Note: Make sure you choose a team where privacy is not secret
+
 If you do not belong to a GitHub team or would like to set up the app without
 doing the above, an alternative is to comment out the line in the controller
 that confirms you are a member of the correct team:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ and then curl with it:
 curl https://api.github.com/user/teams?access_token=YOUR_ACCESS_TOKEN
 ```
 
-Note: Make sure you choose a team where privacy is not secret
+Note: Make sure you choose a team where privacy is not closed
 
 If you do not belong to a GitHub team or would like to set up the app without
 doing the above, an alternative is to comment out the line in the controller


### PR DESCRIPTION
Help others trying to authenticate to select appropriate team id.

Changes proposed in this pull request:
update contribute.md to tip user to select a team with appropriate privacy settings

/cc relevant people
