### PR TITLE
Update omniauth from 1.3.1 to 1.8.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.2)
-    hashie (3.5.5)
+    hashie (3.5.7)
     holidays (5.4.0)
     i18n (0.8.1)
     jquery-rails (4.1.1)
@@ -156,9 +156,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.1)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+    omniauth (1.8.1)
+      hashie (>= 3.4.6, < 3.6.0)
+      rack (>= 1.6.2, < 3)
     omniauth-github (1.1.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.1)
@@ -185,7 +185,7 @@ GEM
       pry (>= 0.9.10)
     public_suffix (2.0.5)
     puma (3.8.0)
-    rack (2.0.1)
+    rack (2.0.5)
     rack-canonical-host (0.2.2)
       addressable (> 0, < 3)
       rack (>= 1.0.0, < 3)
@@ -379,4 +379,4 @@ RUBY VERSION
    ruby 2.3.5p376
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Fixes issue(s) #244 

Changes proposed in this pull request:

- Update omniauth from 1.3.1 to 1.8.1


## _From Commit Message_

The warnings discussed in https://github.com/18F/dolores-landingham-slack-bot/issues/244 come from omniauth's use of the hashie gem. Hashie logged warnings
when one overwrites keys via method setters.

For more information see the [relevant omniauth issue](https://github.com/omniauth/omniauth/issues/872).

## Other

`rake` and `rspec` are passing for me locally.